### PR TITLE
refactor: changed project scope name

### DIFF
--- a/.bun-create/README.md
+++ b/.bun-create/README.md
@@ -24,11 +24,11 @@ The `axm-package` template creates:
 - `README.md`
 - `docs/README.md`
 - `llms.txt`
-- A monorepo-scoped setup that depends on `@axm/typescript-config` (this template is not intended for use outside `axm-internals`)
+- A monorepo-scoped setup that depends on `@axm-internal/typescript-config` (this template is not intended for use outside `axm-internals`)
 
 It also installs dev dependencies and runs a `postinstall` script (Node) that:
 
-- Prompts for package name (defaults to `@axm/<folder-name>`)
+- Prompts for package name (defaults to `@axm-internal/<folder-name>`)
 - Prompts for a short description
 - Rewrites tokens in `README.md`, `llms.txt`, and `docs/README.md`
 - Removes the `bun-create` block from `package.json`
@@ -43,7 +43,7 @@ If prompts do not appear (non-interactive shell), you can set:
 Example (non-interactive):
 
 ```bash
-AXM_PACKAGE_NAME=@axm/http-helper \
+AXM_PACKAGE_NAME=@axm-internal/http-helper \
 AXM_PACKAGE_DESC="HTTP helpers for internal services." \
 bun create axm-package packages/http-helper
 ```

--- a/.bun-create/axm-package/llms.txt
+++ b/.bun-create/axm-package/llms.txt
@@ -9,7 +9,7 @@ Public surface:
 - export(s) from `src/index.ts`
 
 Intended usage:
-- Internal @axm consumers
+- Internal @axm-internal consumers
 
 Non-goals:
 - External/public API stability

--- a/.bun-create/axm-package/package.json
+++ b/.bun-create/axm-package/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@axm/__PACKAGE_NAME__",
+    "name": "@axm-internal/__PACKAGE_NAME__",
     "version": "0.1.0",
     "type": "module",
     "main": "src/index.ts",
@@ -20,7 +20,7 @@
         "postinstall": "node scripts/postcreate.cjs"
     },
     "devDependencies": {
-        "@axm/typescript-config": "*",
+        "@axm-internal/typescript-config": "*",
         "typedoc": "^0.28.2",
         "typedoc-plugin-markdown": "^4.8.1",
         "typescript": "^5",

--- a/.bun-create/axm-package/scripts/postcreate.cjs
+++ b/.bun-create/axm-package/scripts/postcreate.cjs
@@ -8,7 +8,7 @@ const path = require('node:path');
 (async () => {
     const cwd = process.cwd();
     const dirName = path.basename(cwd);
-    const defaultName = `@axm/${dirName}`;
+    const defaultName = `@axm-internal/${dirName}`;
 
     let packageName = (process.env.AXM_PACKAGE_NAME || '').trim();
     let description = (process.env.AXM_PACKAGE_DESC || '').trim();

--- a/.bun-create/axm-package/tsconfig.json
+++ b/.bun-create/axm-package/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "@axm/typescript-config/tsconfig.packages.json"
+    "extends": "@axm-internal/typescript-config/tsconfig.packages.json"
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-@axm:registry=https://npm.pkg.github.com
+@axm-internal:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,13 @@ packages/<name>/
 
 ## Package Rules (Do Not Deviate)
 
-- Package name: `@axm/<kebab-name>`
+- Package name: `@axm-internal/<kebab-name>`
 - `package.json` must follow the canonical form:
-  - Exception: `@axm/typescript-config` is config-only and non-published.
+  - Exception: `@axm-internal/typescript-config` is config-only and non-published.
 
 ```
 {
-  "name": "@axm/<name>",
+  "name": "@axm-internal/<name>",
   "version": "0.1.0",
   "type": "module",
   "main": "src/index.ts",
@@ -67,7 +67,7 @@ Dev dependencies are installed so the post-create hook runs and removes its temp
   - `tests/unit/`
   - `tests/integration/`
 - Use Bun’s built-in test runner.
-- A shared `@axm/test-helpers` package may exist for common utilities.
+- A shared `@axm-internal/test-helpers` package may exist for common utilities.
 
 ## Linting & Formatting
 
@@ -146,13 +146,13 @@ When editing a package from a consuming project:
 bun link
 
 # in consuming project
-bun link @axm/<pkg>
+bun link @axm-internal/<pkg>
 ```
 
 Promote changes by bumping version, publishing, then unlinking in the consumer:
 
 ```
-bun unlink @axm/<pkg>
+bun unlink @axm-internal/<pkg>
 bun install
 ```
 

--- a/apps/prompt-runner/README.md
+++ b/apps/prompt-runner/README.md
@@ -1,4 +1,4 @@
-# @axm/prompt-runner
+# @axm-internal/prompt-runner
 
 Codex prompt runner CLI for this monorepo.
 

--- a/apps/prompt-runner/docs/README.md
+++ b/apps/prompt-runner/docs/README.md
@@ -1,3 +1,3 @@
-# @axm/prompt-runner Documentation
+# @axm-internal/prompt-runner Documentation
 
 Typedoc output should be generated from `src/` and published here or via the central docs site.

--- a/apps/prompt-runner/llms.txt
+++ b/apps/prompt-runner/llms.txt
@@ -1,4 +1,4 @@
-# @axm/prompt-runner
+# @axm-internal/prompt-runner
 Version: 0.1.0
 
 Purpose:

--- a/apps/prompt-runner/package.json
+++ b/apps/prompt-runner/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@axm/prompt-runner",
+    "name": "@axm-internal/prompt-runner",
     "version": "0.1.0",
     "private": true,
     "type": "module",
@@ -19,7 +19,7 @@
         "eta": "^3.5.0"
     },
     "devDependencies": {
-        "@axm/typescript-config": "*",
+        "@axm-internal/typescript-config": "*",
         "typedoc": "^0.28.2",
         "typedoc-plugin-markdown": "^4.8.1",
         "typescript": "^5",

--- a/apps/prompt-runner/tsconfig.json
+++ b/apps/prompt-runner/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "@axm/typescript-config/tsconfig.apps.json"
+    "extends": "@axm-internal/typescript-config/tsconfig.apps.json"
 }

--- a/bun.lock
+++ b/bun.lock
@@ -18,14 +18,14 @@
       },
     },
     "apps/prompt-runner": {
-      "name": "@axm/prompt-runner",
+      "name": "@axm-internal/prompt-runner",
       "version": "0.1.0",
       "dependencies": {
         "commander": "^14.0.2",
         "eta": "^3.5.0",
       },
       "devDependencies": {
-        "@axm/typescript-config": "*",
+        "@axm-internal/typescript-config": "*",
         "@types/bun": "^1.3",
         "typedoc": "^0.28.2",
         "typedoc-plugin-markdown": "^4.8.1",
@@ -33,17 +33,17 @@
       },
     },
     "packages/typescript-config": {
-      "name": "@axm/typescript-config",
+      "name": "@axm-internal/typescript-config",
       "version": "0.1.0",
     },
     "packages/zod-helpers": {
-      "name": "@axm/zod-helpers",
+      "name": "@axm-internal/zod-helpers",
       "version": "0.1.0",
       "dependencies": {
         "zod": "^4.3.5",
       },
       "devDependencies": {
-        "@axm/typescript-config": "*",
+        "@axm-internal/typescript-config": "*",
         "@types/bun": "^1.3",
         "axios": "^1.13.2",
         "pino": "^10.1.1",
@@ -62,11 +62,11 @@
     },
   },
   "packages": {
-    "@axm/prompt-runner": ["@axm/prompt-runner@workspace:apps/prompt-runner"],
+    "@axm-internal/prompt-runner": ["@axm-internal/prompt-runner@workspace:apps/prompt-runner"],
 
-    "@axm/typescript-config": ["@axm/typescript-config@workspace:packages/typescript-config"],
+    "@axm-internal/typescript-config": ["@axm-internal/typescript-config@workspace:packages/typescript-config"],
 
-    "@axm/zod-helpers": ["@axm/zod-helpers@workspace:packages/zod-helpers"],
+    "@axm-internal/zod-helpers": ["@axm-internal/zod-helpers@workspace:packages/zod-helpers"],
 
     "@babel/code-frame": ["@babel/code-frame@7.28.6", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q=="],
 

--- a/monorepo-docs/conventions.md
+++ b/monorepo-docs/conventions.md
@@ -33,18 +33,18 @@ packages/<name>/
 
 Rules:
 
-* All packages are named `@axm/<kebab-name>`
+* All packages are named `@axm-internal/<kebab-name>`
 * All packages are Bun‑first and ESM‑only
 * Entry point is always `src/index.ts`
 * No build step (TypeScript is consumed directly by Bun)
 * Turborepo orchestrates repo-wide tasks (lint, test, check-types, validate)
 * All packages are versioned and published via Changesets
 * `package.json` always follows the canonical form:
-  * Exception: config-only, non-published support packages (e.g., `@axm/typescript-config`)
+  * Exception: config-only, non-published support packages (e.g., `@axm-internal/typescript-config`)
 
 ```json
 {
-  "name": "@axm/<name>",
+  "name": "@axm-internal/<name>",
   "version": "0.1.0",
   "type": "module",
   "main": "src/index.ts",
@@ -82,7 +82,7 @@ This template:
 Non-interactive usage:
 
 ```bash
-AXM_PACKAGE_NAME=@axm/http-helper \
+AXM_PACKAGE_NAME=@axm-internal/http-helper \
 AXM_PACKAGE_DESC="HTTP helpers for internal services." \
 bun create axm-package packages/http-helper
 ```
@@ -113,7 +113,7 @@ Guidelines:
     * `tests/integration/` – filesystem, process, IO, etc.
 * Packages may add more layers if needed (e.g. `e2e/`)
 
-A shared `@axm/test-helpers` package may provide:
+A shared `@axm-internal/test-helpers` package may provide:
 
 * Temp directories
 * Fixture helpers

--- a/monorepo-docs/overview.md
+++ b/monorepo-docs/overview.md
@@ -45,7 +45,7 @@ Each package is a *real* npm package, but **source-first** and **buildless**:
 ```json
 // packages/cli-helper/package.json
 {
-  "name": "@axm/cli-helper",
+  "name": "@axm-internal/cli-helper",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -60,7 +60,7 @@ Because everything runs on Bun:
 - No `tsc` or bundling step
 - Publishing ships *source*, not artifacts
 
-`@axm/*` becomes your internal, living standard library.
+`@axm-internal/*` becomes your internal, living standard library.
 
 ---
 
@@ -71,8 +71,8 @@ In any project (Alpha, Beta, Delta):
 ```json
 {
   "dependencies": {
-    "@axm/cli-helper": "^0.1.0",
-    "@axm/logger": "^0.2.0"
+    "@axm-internal/cli-helper": "^0.1.0",
+    "@axm-internal/logger": "^0.2.0"
   }
 }
 ```
@@ -96,12 +96,12 @@ When you’re in Project Beta and realize `cli-helper` needs improvement, you do
 bun link
 
 # in Project Beta
-bun link @axm/cli-helper
+bun link @axm-internal/cli-helper
 ```
 
 Now:
 
-- `@axm/cli-helper` resolves to your local source
+- `@axm-internal/cli-helper` resolves to your local source
 - You can edit `src/index.ts` in real time
 - Beta reflects changes immediately
 
@@ -119,7 +119,7 @@ When the fix or feature is ready:
 4. In the consuming project:
 
 ```bash
-bun unlink @axm/cli-helper
+bun unlink @axm-internal/cli-helper
 bun install
 ```
 

--- a/monorepo-docs/release-versioning-pipeline.md
+++ b/monorepo-docs/release-versioning-pipeline.md
@@ -50,7 +50,7 @@ Example:
 
 ```md
 ---
-"@axm/cli-helper": minor
+"@axm-internal/cli-helper": minor
 ---
 
 Add structured logging and improve error output.
@@ -84,7 +84,7 @@ Changesets become the source of truth for:
 7. Packages are pushed to **GitHub Packages**
 8. A release commit and tags are created
 
-Projects consuming `@axm/*` now have new versions available and can upgrade intentionally.
+Projects consuming `@axm-internal/*` now have new versions available and can upgrade intentionally.
 
 ---
 
@@ -94,7 +94,7 @@ Each package declares its registry:
 
 ```json
 {
-  "name": "@axm/cli-helper",
+  "name": "@axm-internal/cli-helper",
   "version": "0.1.0",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com"
@@ -105,7 +105,7 @@ Each package declares its registry:
 The repository includes an `.npmrc`:
 
 ```txt
-@axm:registry=https://npm.pkg.github.com
+@axm-internal:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 ```
 

--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -1,4 +1,4 @@
-# @axm/typescript-config
+# @axm-internal/typescript-config
 
 Centralized TypeScript configurations for the monorepo.
 
@@ -44,7 +44,7 @@ Extends packages configuration for decorator-using packages:
 ### For Apps (CLI, Web)
 ```json
 {
-  "extends": "@axm/typescript-config/tsconfig.apps.json",
+  "extends": "@axm-internal/typescript-config/tsconfig.apps.json",
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src"
@@ -55,14 +55,14 @@ Extends packages configuration for decorator-using packages:
 ### For Regular Packages (shared-core, shared-services)
 ```json
 {
-  "extends": "@axm/typescript-config/tsconfig.packages.json"
+  "extends": "@axm-internal/typescript-config/tsconfig.packages.json"
 }
 ```
 
 ### For Decorator Packages (database, queues)
 ```json
 {
-  "extends": "@axm/typescript-config/tsconfig.decorators.json"
+  "extends": "@axm-internal/typescript-config/tsconfig.decorators.json"
 }
 ```
 

--- a/packages/typescript-config/docs/README.md
+++ b/packages/typescript-config/docs/README.md
@@ -1,3 +1,3 @@
-# @axm/typescript-config Documentation
+# @axm-internal/typescript-config Documentation
 
 Typedoc output should be generated from `src/` and published here or via the central docs site.

--- a/packages/typescript-config/llms.txt
+++ b/packages/typescript-config/llms.txt
@@ -1,4 +1,4 @@
-# @axm/typescript-config
+# @axm-internal/typescript-config
 Version: 0.1.0
 
 Purpose:
@@ -12,7 +12,7 @@ Public surface:
 - No runtime exports (config-only package)
 
 Intended usage:
-- Internal @axm consumers
+- Internal @axm-internal consumers
 
 Non-goals:
 - External/public API stability

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@axm/typescript-config",
+    "name": "@axm-internal/typescript-config",
     "version": "0.1.0",
     "private": true,
     "description": "Config-only TypeScript configurations (non-published)",

--- a/packages/zod-helpers/README.md
+++ b/packages/zod-helpers/README.md
@@ -1,17 +1,17 @@
-# @axm/zod-helpers
+# @axm-internal/zod-helpers
 
 A collection of Zod v4 helpers.
 
 ## Install
 
 ```bash
-bun add @axm/zod-helpers
+bun add @axm-internal/zod-helpers
 ```
 
 ## Usage
 
 ```ts
-import { AxiosInstanceSchema, PinoInstanceSchema } from "@axm/zod-helpers";
+import { AxiosInstanceSchema, PinoInstanceSchema } from "@axm-internal/zod-helpers";
 
 AxiosInstanceSchema.parse(axiosInstance);
 PinoInstanceSchema.parse(logger);

--- a/packages/zod-helpers/docs/README.md
+++ b/packages/zod-helpers/docs/README.md
@@ -1,21 +1,21 @@
-**@axm/zod-helpers**
+**@axm-internal/zod-helpers**
 
 ***
 
-# @axm/zod-helpers
+# @axm-internal/zod-helpers
 
 A collection of Zod v4 helpers.
 
 ## Install
 
 ```bash
-bun add @axm/zod-helpers
+bun add @axm-internal/zod-helpers
 ```
 
 ## Usage
 
 ```ts
-import { AxiosInstanceSchema, PinoInstanceSchema } from "@axm/zod-helpers";
+import { AxiosInstanceSchema, PinoInstanceSchema } from "@axm-internal/zod-helpers";
 
 AxiosInstanceSchema.parse(axiosInstance);
 PinoInstanceSchema.parse(logger);

--- a/packages/zod-helpers/docs/globals.md
+++ b/packages/zod-helpers/docs/globals.md
@@ -1,8 +1,8 @@
-[**@axm/zod-helpers**](README.md)
+[**@axm-internal/zod-helpers**](README.md)
 
 ***
 
-# @axm/zod-helpers
+# @axm-internal/zod-helpers
 
 ## Variables
 

--- a/packages/zod-helpers/docs/variables/AxiosInstanceSchema.md
+++ b/packages/zod-helpers/docs/variables/AxiosInstanceSchema.md
@@ -1,8 +1,8 @@
-[**@axm/zod-helpers**](../README.md)
+[**@axm-internal/zod-helpers**](../README.md)
 
 ***
 
-[@axm/zod-helpers](../globals.md) / AxiosInstanceSchema
+[@axm-internal/zod-helpers](../globals.md) / AxiosInstanceSchema
 
 # Variable: AxiosInstanceSchema
 

--- a/packages/zod-helpers/docs/variables/PinoInstanceSchema.md
+++ b/packages/zod-helpers/docs/variables/PinoInstanceSchema.md
@@ -1,8 +1,8 @@
-[**@axm/zod-helpers**](../README.md)
+[**@axm-internal/zod-helpers**](../README.md)
 
 ***
 
-[@axm/zod-helpers](../globals.md) / PinoInstanceSchema
+[@axm-internal/zod-helpers](../globals.md) / PinoInstanceSchema
 
 # Variable: PinoInstanceSchema
 

--- a/packages/zod-helpers/llms.txt
+++ b/packages/zod-helpers/llms.txt
@@ -1,4 +1,4 @@
-# @axm/zod-helpers
+# @axm-internal/zod-helpers
 
 Version: 0.1.0
 

--- a/packages/zod-helpers/package.json
+++ b/packages/zod-helpers/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@axm/zod-helpers",
+    "name": "@axm-internal/zod-helpers",
     "version": "0.1.0",
     "type": "module",
     "main": "src/index.ts",
@@ -17,7 +17,7 @@
         "validate": "echo \"Validated\""
     },
     "devDependencies": {
-        "@axm/typescript-config": "*",
+        "@axm-internal/typescript-config": "*",
         "axios": "^1.13.2",
         "pino": "^10.1.1",
         "typedoc": "^0.28.2",

--- a/packages/zod-helpers/src/index.ts
+++ b/packages/zod-helpers/src/index.ts
@@ -5,7 +5,7 @@
  * Exported schemas use structural checks for lightweight runtime validation.
  * @example
  * ```ts
- * import { AxiosInstanceSchema, PinoInstanceSchema } from "@axm/zod-helpers";
+ * import { AxiosInstanceSchema, PinoInstanceSchema } from "@axm-internal/zod-helpers";
  *
  * AxiosInstanceSchema.parse(axios.create());
  * PinoInstanceSchema.parse(pino());

--- a/packages/zod-helpers/tsconfig.json
+++ b/packages/zod-helpers/tsconfig.json
@@ -1,3 +1,3 @@
 {
-    "extends": "@axm/typescript-config/tsconfig.packages.json"
+    "extends": "@axm-internal/typescript-config/tsconfig.packages.json"
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the npm scope from @axm to @axm-internal across the monorepo to clarify internal-only packages and align with our private registry. No runtime or API changes.

- **Refactors**
  - Updated package names and imports to @axm-internal/*
  - Switched tsconfig extends to @axm-internal/typescript-config
  - Set .npmrc registry to @axm-internal
  - Revised docs, READMEs, and templates to the new scope
  - Updated bun.lock to reflect renamed workspaces

- **Migration**
  - Update consumer dependencies from @axm/* to @axm-internal/*
  - Replace imports in code to @axm-internal/*
  - Ensure .npmrc includes @axm-internal:registry pointing to GitHub Packages
  - If using bun link, relink with the new scope (bun link @axm-internal/<pkg>) and reinstall

<sup>Written for commit 378b3af15ea55b76b03ee56a6b82cba330d9851f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

