### PR TITLE
docs: updated docs to reflect visibility change to packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ It also removes the nested `.git` folder created by `bun create`.
 - `packages/typescript-config/README.md`
 - `apps/prompt-runner/README.md`
 
+## Examples Repo
+
+`axm-internals/axm-examples` is the companion repo for testing published `@axm-internal/*` packages.
+
 ## Docs
 
 - `monorepo-docs/package-checklist.md`
@@ -42,7 +46,7 @@ This project was created using `bun init` in bun v1.3.4. [Bun](https://bun.com) 
 
 ## Releases
 
-We use Changesets for versioning and publishing to GitHub Packages.
+We use Changesets for versioning and publishing public `@axm-internal/*` packages.
 
 Flow:
 
@@ -75,3 +79,24 @@ Or use the root script:
 ```bash
 bun clean
 ```
+
+## Package Installation
+
+`@axm-internal/*` packages are public and published to GitHub Packages. GitHub Packages
+still requires authentication for installs, so consumers must configure an auth token.
+
+Local setup (one-time):
+
+```bash
+echo "@axm-internal:registry=https://npm.pkg.github.com" >> ~/.npmrc
+echo "//npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN" >> ~/.npmrc
+```
+
+Then install as usual:
+
+```bash
+bun add @axm-internal/zod-helpers
+```
+
+CI setup should write the token to the repo `.npmrc` and include `packages: read`
+permissions for the workflow.

--- a/monorepo-docs/intro-to-changesets.md
+++ b/monorepo-docs/intro-to-changesets.md
@@ -34,7 +34,7 @@ bun changeset
 
 ## Publishing
 
-Publishing is triggered by pushes to `main` **when changesets exist**. The workflow uses `changeset publish` to publish affected packages to GitHub Packages.
+Publishing is triggered by pushes to `main` **when changesets exist**. The workflow uses `changeset publish` to publish affected public packages.
 
 ## Changelogs
 

--- a/monorepo-docs/release-versioning-pipeline.md
+++ b/monorepo-docs/release-versioning-pipeline.md
@@ -8,7 +8,7 @@ The goals are:
 * Zero surprise breakage for consuming projects
 * Clear, intentional upgrades
 * Automated changelogs
-* Seamless publishing to GitHub Packages
+* Seamless publishing of public packages
 
 The chosen tool for this is **Changesets**.
 
@@ -81,14 +81,14 @@ Changesets become the source of truth for:
     * Bumps package versions
     * Generates changelogs
     * Publishes only affected packages
-7. Packages are pushed to **GitHub Packages**
+7. Packages are pushed to the registry
 8. A release commit and tags are created
 
 Projects consuming `@axm-internal/*` now have new versions available and can upgrade intentionally.
 
 ---
 
-## GitHub Packages Integration
+## Registry Integration
 
 Each package declares its registry:
 
@@ -102,7 +102,7 @@ Each package declares its registry:
 }
 ```
 
-The repository includes an `.npmrc`:
+The repository includes an `.npmrc` for publishing:
 
 ```txt
 @axm-internal:registry=https://npm.pkg.github.com


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated docs to reflect that @axm-internal/* packages are now public while still published to GitHub Packages and require auth for installs. Also added install steps, CI guidance, and an examples repo link.

- **Docs**
  - Added Examples Repo section for axm-internals/axm-examples.
  - Added Package Installation instructions with .npmrc token setup and CI notes.
  - Clarified publishing flow for public packages and generalized “GitHub Packages” to “registry” where appropriate.

<sup>Written for commit 6673415545fb16cc5fe0f99b3b3bdac9fac8f4c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

