### PR TITLE
fix: fixed release commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,7 @@ jobs:
         with:
           version: bunx changeset version
           publish: bunx changeset publish
+          commit: "chore(release): versioned packages"
+          title: "chore(release): versioned packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardizes the Changesets release commit message by setting commit and title to "chore(release): versioned packages" in the release workflow, fixing inconsistent or missing messages in automated releases.

<sup>Written for commit ddf63e15f7f3c72770ce079403c7bd9c09a5b8b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

