### PR TITLE
chore(release): prepared release changesets

### DIFF
--- a/.changelogs/repo-cli.json
+++ b/.changelogs/repo-cli.json
@@ -37,6 +37,21 @@
                 "docs(repo-cli): updated changeset related docs for future refactor"
             ],
             "createdAt": "2026-01-26T20:53:42.258Z"
+        },
+        {
+            "version": "2026-01-26T22:37:54-05:00",
+            "tag": null,
+            "fromHash": "2527ff865af9ddbdfe3100884bced729a73c7dfe",
+            "toHash": "2dc84ef6274398e3bcaf1ce3e041f6b483529b01",
+            "rangeStartDate": "2026-01-26T15:55:37-05:00",
+            "rangeEndDate": "2026-01-26T22:37:54-05:00",
+            "summaryLines": [
+                "docs: created backfilll changelogs",
+                "fix(repo-cli): excluded tag commit when building changeset drafts",
+                "fix(repo-cli): fixed number to boolean conversion",
+                "feat(repo-cli): completed json -> md conversion of changesets"
+            ],
+            "createdAt": "2026-01-27T17:24:47.716Z"
         }
     ]
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,13 +4,21 @@ This repo uses Changesets for versioning and publishing. Manual releases are dri
 
 ## Manual Release Flow
 
-1) Update the git-db index so release data is current:
+1) Create a release branch from `main`:
+
+```bash
+git checkout main
+git pull
+git checkout -b release/<yyyy-mm-dd>
+```
+
+2) Update the git-db index so release data is current:
 
 ```bash
 ./repo-cli gitdb:index
 ```
 
-1b) (Optional) Backfill or render changelogs from `.changelogs/`:
+3) (Optional) Backfill or render changelogs from `.changelogs/`:
 
 ```bash
 ./repo-cli changelog:backfill --all --dry
@@ -18,39 +26,44 @@ This repo uses Changesets for versioning and publishing. Manual releases are dri
 ./repo-cli changelog:write --all
 ```
 
-2) Preview draft release data for the package(s) you plan to release:
+4) Preview changesets for the package(s) you plan to release:
 
 ```bash
 ./repo-cli changesets:create packages/cli-kit --dry
 ./repo-cli changesets:create --all --dry
 ```
 
-3) Write draft files for the package(s) you plan to release:
+5) Write changeset files for the package(s) you plan to release:
 
 ```bash
 ./repo-cli changesets:create packages/cli-kit
 ./repo-cli changesets:create --all
 ```
 
-Drafts are written to `.changeset-drafts/` at the repo root. Use these drafts to prepare your official Changesets.
+Changesets are written to `.changeset/` at the repo root. Drafts (JSON) are written to
+`.changeset-drafts/` for reference.
 
-4) Create actual Changesets (the files under `.changeset/`) using the draft data:
-
-```bash
-bun changeset
-```
-
-When prompted, select the target package(s), choose the bump type, and paste a summary derived from the draft(s).
-
-5) Commit code + `.changeset` files and open a PR:
+6) Commit code + `.changeset` files and open a PR:
 
 ```bash
 git status
 git add .
-git commit -m "Prepared release changesets"
+git commit -m "chore(release): prepared release changesets"
 ```
 
-6) Merge to `main`. The Release workflow will run and publish the updated packages.
+7) Merge the PR to `main`.
+
+8) From `main`, version and publish:
+
+```bash
+git checkout main
+git pull
+bunx changeset version
+git add .
+git commit -m "chore(release): versioned packages"
+git push
+bunx changeset publish
+```
 
 ## Notes
 

--- a/apps/repo-cli/CHANGELOG.md
+++ b/apps/repo-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2026-01-26T22:37:54-05:00
+- docs: created backfilll changelogs
+- fix(repo-cli): excluded tag commit when building changeset drafts
+- fix(repo-cli): fixed number to boolean conversion
+- feat(repo-cli): completed json -> md conversion of changesets
+
 ## 2026-01-26T15:43:18-05:00
 - refactor(repo-cli): scoped prompt-runner commands
 - feat(repo-cli): created better package/app validation


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepared release changesets by backfilling repo-cli changelogs and updating RELEASING.md with a clearer manual release flow. Standardized changeset creation via repo-cli, clarified .changeset vs .changeset-drafts, and added version/publish steps.

- **New Features**
  - Completed JSON → MD conversion for changesets.
  - Added changelog backfill data.

- **Bug Fixes**
  - Excluded tag commits when building changeset drafts.
  - Fixed number-to-boolean conversion in repo-cli.

<sup>Written for commit b89a46f41b9db3403e241ff5d30b611795877d2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

