### PR TITLE
Ci/no publish unpublished

### DIFF
--- a/.changelogs/hono-kit.json
+++ b/.changelogs/hono-kit.json
@@ -1,0 +1,33 @@
+{
+    "scope": "hono-kit",
+    "entries": [
+        {
+            "version": "2026-02-03T16:45:48-05:00",
+            "tag": null,
+            "fromHash": "f9cbefdefa86cd551927e9105c6515abac01701a",
+            "toHash": "08f3444db80313596672f92b7e1d52289c098be4",
+            "rangeStartDate": "2026-01-20T20:45:23-05:00",
+            "rangeEndDate": "2026-02-03T16:45:48-05:00",
+            "summaryLines": [
+                "chore(hono-kit): scaffolded package skeleton",
+                "feat(hono-kit): added core types and error handler",
+                "feat(hono-kit): added pino logging integration",
+                "feat(hono-kit): implemented input validation and validation errors",
+                "feat(hono-kit): added route builder and route types",
+                "feat(hono-kit): added response payload validation",
+                "feat(hono-kit): added routes collection and registration",
+                "feat(hono-kit): added default middleware bundle",
+                "feat(hono-kit): added auth helpers",
+                "feat(hono-kit): implemented server wrapper and factory",
+                "chore(hono-kit): added dup check scripts",
+                "refactor(hono-kit): deduped joinPaths helper",
+                "test(hono-kit): added server integration coverage",
+                "docs(hono-kit): documented public api and usage",
+                "docs(hono-kit): documented public api and usage",
+                "chore: reducing PR size",
+                "fix(hono-kit): handled auth errors and logging correctly"
+            ],
+            "createdAt": "2026-02-03T23:06:19.536Z"
+        }
+    ]
+}

--- a/.changelogs/root.json
+++ b/.changelogs/root.json
@@ -155,6 +155,21 @@
             ],
             "createdAt": "2026-01-28T10:51:45.919Z",
             "scope": "zod-helpers"
+        },
+        {
+            "version": "2026-02-03T16:45:48-05:00",
+            "tag": null,
+            "fromHash": "f9cbefdefa86cd551927e9105c6515abac01701a",
+            "toHash": "08f3444db80313596672f92b7e1d52289c098be4",
+            "rangeStartDate": "2026-01-20T20:45:23-05:00",
+            "rangeEndDate": "2026-02-03T16:45:48-05:00",
+            "summaryLines": [
+                "chore: saving codex session",
+                "chore: removed sample http-helper",
+                "chore: reducing PR size"
+            ],
+            "createdAt": "2026-02-03T23:06:19.539Z",
+            "scope": "hono-kit"
         }
     ]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,17 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun run validate
+      - name: Check for changesets
+        id: changesets
+        run: |
+          set -euo pipefail
+          if ls .changeset/*.md >/dev/null 2>&1; then
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Version & Publish
+        if: steps.changesets.outputs.has_changesets == 'true'
         uses: changesets/action@v1
         with:
           version: bunx changeset version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-02-03T16:45:48-05:00
+- chore: saving codex session
+- chore: removed sample http-helper
+- chore: reducing PR size
+
 ## 2026-01-28T02:39:57-05:00
 - docs: added back-log list to track future work
 - feat: changed typedoc configs to exclude @internal symbols

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,7 @@ Merge the PR to `main`.
 
 ## Publishing (CI)
 
-On merge to `main`, the existing Release workflow will:
+On merge to `main`, the existing Release workflow will run **only when changesets exist** and will:
 
 ```bash
 bunx changeset version
@@ -61,3 +61,4 @@ Open a PR, merge to `main`, and CI will publish.
 - Releases are driven by the presence of `.changeset/*.md` files.
 - If a package should not be released, do not add a changeset for it.
 - Use `.changeset-drafts/` as the source of truth for what changed since the last tag.
+- CI will skip versioning/publishing entirely when no `.changeset/*.md` files are present.

--- a/apps/repo-cli/CHANGELOG.md
+++ b/apps/repo-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2026-01-28T06:26:12-05:00
+- docs: updated changelogs
+- test(repo-cli): increased test coverage
+
 ## 2026-01-28T05:50:56-05:00
 - chore(release): prepared release changesets
 - chore(release): versioned packages

--- a/packages/hono-kit/CHANGELOG.md
+++ b/packages/hono-kit/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 2026-02-03T16:45:48-05:00
+- chore(hono-kit): scaffolded package skeleton
+- feat(hono-kit): added core types and error handler
+- feat(hono-kit): added pino logging integration
+- feat(hono-kit): implemented input validation and validation errors
+- feat(hono-kit): added route builder and route types
+- feat(hono-kit): added response payload validation
+- feat(hono-kit): added routes collection and registration
+- feat(hono-kit): added default middleware bundle
+- feat(hono-kit): added auth helpers
+- feat(hono-kit): implemented server wrapper and factory
+- chore(hono-kit): added dup check scripts
+- refactor(hono-kit): deduped joinPaths helper
+- test(hono-kit): added server integration coverage
+- docs(hono-kit): documented public api and usage
+- docs(hono-kit): documented public api and usage
+- chore: reducing PR size
+- fix(hono-kit): handled auth errors and logging correctly


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop publishing on merge when no changesets exist. The release workflow now skips versioning/publishing unless .changeset files are present, and docs explain this behavior.

- **Bug Fixes**
  - Release workflow checks for .changeset/*.md and skips version/publish when none are found.
  - Updated RELEASING.md to reflect the gated publishing.
  - Added/updated changelogs for hono-kit, repo-cli, and root; no functional code changes.

<sup>Written for commit c720e00da9e78dcf92f2e8df801eb22685354ebe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

