### PR TITLE
refactor(repo-cli): derived package apps from filesystem

### DIFF
--- a/apps/repo-cli/src/schemas/PackageAppSchema.ts
+++ b/apps/repo-cli/src/schemas/PackageAppSchema.ts
@@ -1,23 +1,38 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { z } from 'zod';
+import { findRepoRoot } from '../utils/findRepoRoot';
 
-const validPackageApps = [
-    'apps/repo-cli',
-    'packages/cli-kit',
-    'packages/hono-kit',
-    'packages/config-schema',
-    'packages/git-db',
-    'packages/tooling-config',
-    'packages/zod-helpers',
-] as const;
+const listPackageDirs = (root: string, folder: 'apps' | 'packages'): string[] => {
+    const basePath = path.join(root, folder);
+    if (!fs.existsSync(basePath)) {
+        return [];
+    }
+    return fs
+        .readdirSync(basePath, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => `${folder}/${entry.name}`);
+};
 
-const validPackageAppSet = new Set<string>(validPackageApps);
+const buildValidPackageApps = (): string[] => {
+    const repoRoot = findRepoRoot(process.cwd());
+    return [...listPackageDirs(repoRoot, 'apps'), ...listPackageDirs(repoRoot, 'packages')].sort();
+};
+
+export const getValidPackageApps = (): string[] => {
+    return buildValidPackageApps();
+};
+
+const getValidPackageAppSet = (): Set<string> => {
+    return new Set<string>(buildValidPackageApps());
+};
 
 export const ValidatePackageApp = (packageApp?: string): true => {
     if (!packageApp) {
         throw new Error('Package or app name is required');
     }
 
-    if (!validPackageAppSet.has(packageApp)) {
+    if (!getValidPackageAppSet().has(packageApp)) {
         throw new Error(`Unknown package or app "${packageApp}".`);
     }
 
@@ -25,11 +40,11 @@ export const ValidatePackageApp = (packageApp?: string): true => {
 };
 
 export const isValidPackageApp = (packageApp?: string): boolean => {
-    return Boolean(packageApp && validPackageAppSet.has(packageApp));
+    return Boolean(packageApp && getValidPackageAppSet().has(packageApp));
 };
 
-export const PackageAppSchema = z.enum(validPackageApps, {
-    error: () => 'Expected a known "apps/<name>" or "packages/<name>" value.',
+export const PackageAppSchema = z.string().refine((value) => getValidPackageAppSet().has(value), {
+    message: 'Expected a known "apps/<name>" or "packages/<name>" value.',
 });
 
 export type PackageApp = z.infer<typeof PackageAppSchema>;

--- a/apps/repo-cli/src/schemas/PackageAppSchema.ts
+++ b/apps/repo-cli/src/schemas/PackageAppSchema.ts
@@ -11,6 +11,9 @@ const listPackageDirs = (root: string, folder: 'apps' | 'packages'): string[] =>
     return fs
         .readdirSync(basePath, { withFileTypes: true })
         .filter((entry) => entry.isDirectory())
+        .filter((entry) => {
+            return fs.existsSync(path.join(basePath, entry.name, 'package.json'));
+        })
         .map((entry) => `${folder}/${entry.name}`);
 };
 

--- a/apps/repo-cli/src/utils/listPackageApps.ts
+++ b/apps/repo-cli/src/utils/listPackageApps.ts
@@ -1,5 +1,5 @@
-import { PackageAppSchema } from '../schemas/PackageAppSchema';
+import { getValidPackageApps } from '../schemas/PackageAppSchema';
 
 export const listPackageApps = (): string[] => {
-    return [...PackageAppSchema.options];
+    return getValidPackageApps();
 };

--- a/apps/repo-cli/tests/unit/services/ChangelogBuilder.test.ts
+++ b/apps/repo-cli/tests/unit/services/ChangelogBuilder.test.ts
@@ -232,14 +232,14 @@ describe('ChangelogBuilder', () => {
         await store.writeRoot({
             entries: [
                 {
-                    scope: 'cli-kit',
-                    version: '0.1.0',
-                    tag: '@axm-internal/cli-kit@0.1.0',
+                    scope: 'root',
+                    version: '2026-01-01T00:00:00.000Z',
+                    tag: null,
                     fromHash: 'a1',
                     toHash: 'a1',
                     rangeStartDate: '2026-01-01T00:00:00.000Z',
                     rangeEndDate: '2026-01-01T00:00:00.000Z',
-                    summaryLines: ['feat(cli-kit): init'],
+                    summaryLines: ['chore: root metadata'],
                     createdAt: '2026-01-01T00:00:00.000Z',
                 },
             ],
@@ -248,6 +248,10 @@ describe('ChangelogBuilder', () => {
         try {
             process.chdir(repoRoot);
             await fs.promises.mkdir(path.join(repoRoot, 'packages/cli-kit'), { recursive: true });
+            await fs.promises.writeFile(
+                path.join(repoRoot, 'packages/cli-kit/package.json'),
+                JSON.stringify({ name: '@axm-internal/cli-kit', version: '0.1.0' })
+            );
             await builder.writeMarkdown(['packages/cli-kit']);
         } finally {
             process.chdir(cwd);
@@ -258,6 +262,7 @@ describe('ChangelogBuilder', () => {
 
         expect(packageChangelog.includes('## 0.1.0')).toBe(true);
         expect(rootChangelog.includes('## 2026-01-01T00:00:00.000Z')).toBe(true);
+        expect(rootChangelog.includes('chore: root metadata')).toBe(true);
     });
 
     it('resolves package targets from flags', () => {


### PR DESCRIPTION
- Replaced the hard-coded package/app allowlist with runtime discovery under `apps/` and `packages/`.
- Updated validation helpers and schema checks to use the dynamic set.
- Switched listPackageApps to return the discovered package/app list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives valid package/app names from the filesystem at runtime, replacing the hard-coded allowlist. Keeps repo-cli validation in sync with apps/ and packages/ changes and removes manual updates.

- **Refactors**
  - Scan apps/ and packages/ from the repo root, including only directories with a package.json.
  - Replace z.enum with a z.string + refine check against the dynamic set.
  - Update listPackageApps to return the discovered list.

<sup>Written for commit 081aa19dd25fa1feab54a39380b2f8188b1db32f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

