### PR TITLE
fix(config-schema): moved zod-helpers to runtime deps

### DIFF
--- a/packages/config-schema/package.json
+++ b/packages/config-schema/package.json
@@ -19,17 +19,17 @@
         "docs": "typedoc",
         "validate": "echo \"Validated\""
     },
+    "dependencies": {
+        "@axm-internal/zod-helpers": "*",
+        "dotenv": "^17.2.3",
+        "dotenv-expand": "^12.0.3",
+        "zod": "^4.3.5"
+    },
     "devDependencies": {
         "@axm-internal/tooling-config": "*",
-        "@axm-internal/zod-helpers": "*",
         "typedoc": "^0.28.2",
         "typedoc-plugin-markdown": "^4.8.1",
         "typescript": "^5",
         "@types/bun": "^1.3"
-    },
-    "dependencies": {
-        "dotenv": "^17.2.3",
-        "dotenv-expand": "^12.0.3",
-        "zod": "^4.3.5"
     }
 }


### PR DESCRIPTION
- shifted @axm-internal/zod-helpers from devDependencies to dependencies
- aligned config-schema runtime requirements with packaging

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved @axm-internal/zod-helpers from devDependencies to dependencies in config-schema to make it available at runtime and prevent missing module errors. Aligns the package’s runtime requirements with how it's packaged.

<sup>Written for commit 6b60d7779acc0f9623002271887e19f69bdffbfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

