### PR TITLE
feat(cli-kit): allowed suppressing default error logging

### DIFF
--- a/apps/repo-cli/src/cli.ts
+++ b/apps/repo-cli/src/cli.ts
@@ -19,6 +19,7 @@ const cliApp = new CliApp({
     options: {
         container: appContainer,
         pretty: true,
+        logErrors: false,
         commandDefinitions: [...promptRunnerCommands, ...gitDbCommands, ...changesetCommands, ...changelogCommands],
         onError: (error) => {
             if (error instanceof ZodError) {

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
     "vcs": {
         "enabled": true,
         "clientKind": "git",

--- a/packages/cli-kit/README.md
+++ b/packages/cli-kit/README.md
@@ -66,6 +66,7 @@ const app = new CliApp({
   config: { name: 'my-cli', description: 'Example CLI' },
   options: {
     commandDefinitions: [helloCommand],
+    logErrors: false,
     onError: (error, container) => {
       const logger = container.resolve(CliLogger);
       logger.fatal(error, 'CLI failed');
@@ -102,6 +103,7 @@ const helloCommand = createCommandDefinition<DependencyContainer>({
 - Option aliases can be defined via `meta.aliases`.
 - Optional lightweight container for dependency resolution.
 - Hooks (`onError`, `onExit`) receive the container for test-friendly flows.
+- Set `logErrors` to `false` when you handle error output yourself.
 
 ## Notes
 

--- a/packages/cli-kit/docs/README.md
+++ b/packages/cli-kit/docs/README.md
@@ -70,6 +70,7 @@ const app = new CliApp({
   config: { name: 'my-cli', description: 'Example CLI' },
   options: {
     commandDefinitions: [helloCommand],
+    logErrors: false,
     onError: (error, container) => {
       const logger = container.resolve(CliLogger);
       logger.fatal(error, 'CLI failed');
@@ -81,6 +82,23 @@ const exitCode = await app.start();
 process.exit(exitCode);
 ```
 
+### Container Typing (Generic Alias)
+
+If your project uses a DI container like tsyringe, pass the container type as the generic argument to align the
+`container` type inside `action`:
+
+```ts
+import type { DependencyContainer } from 'tsyringe';
+
+const helloCommand = createCommandDefinition<DependencyContainer>({
+  name: 'hello',
+  description: 'says hello',
+  action: async ({ container }) => {
+    // container is typed as DependencyContainer here
+  },
+});
+```
+
 ## Highlights
 
 - Thin wrapper around Commander with typed command definitions.
@@ -89,6 +107,7 @@ process.exit(exitCode);
 - Option aliases can be defined via `meta.aliases`.
 - Optional lightweight container for dependency resolution.
 - Hooks (`onError`, `onExit`) receive the container for test-friendly flows.
+- Set `logErrors` to `false` when you handle error output yourself.
 
 ## Notes
 
@@ -97,6 +116,10 @@ process.exit(exitCode);
 - Default logger level is `fatal` (use `--debug` to switch to `debug`).
 - Positional arguments are strings by default; use `z.coerce.*` when you need numeric or boolean args.
 - Avoid Zod function defaults for CLI arguments/options; Commander treats functions as parsers.
+
+## Breaking Changes
+
+- Defaults are no longer inferred from `schema.default(...)` unless you also provide `meta({ defaultValue })`. Use `schema.meta({ defaultValue })` to keep Commander defaults and help text in sync.
 
 ## Docs
 

--- a/packages/cli-kit/docs/classes/CliApp.md
+++ b/packages/cli-kit/docs/classes/CliApp.md
@@ -27,7 +27,7 @@ await app.start();
 
 > **new CliApp**(`params`): `CliApp`
 
-Defined in: [CliApp.ts:45](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L45)
+Defined in: [CliApp.ts:46](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L46)
 
 Create a new CLI app instance.
 
@@ -55,7 +55,7 @@ App configuration and options.
 
 ###### options
 
-\{ `commandDefinitions?`: `object`[]; `container?`: [`ContainerInterface`](../interfaces/ContainerInterface.md); `logger?`: `Logger`; `loggerAliases?`: [`InjectionToken`](../type-aliases/InjectionToken.md)\<`unknown`\>[]; `onError?`: `$InferOuterFunctionType`\<`ZodTuple`\<\[`ZodCustom`\<`Error`, `Error`\>\], `null`\>, `ZodVoid`\>; `onExit?`: `$InferOuterFunctionType`\<`ZodTuple`\<\[`ZodNumber`, `ZodOptional`\<`ZodCustom`\<`Error`, `Error`\>\>\], `null`\>, `ZodVoid`\>; `pretty`: `boolean`; \} = `CliOptionsSchema`
+\{ `commandDefinitions?`: `object`[]; `container?`: [`ContainerInterface`](../interfaces/ContainerInterface.md); `logErrors`: `boolean`; `logger?`: `Logger`; `loggerAliases?`: [`InjectionToken`](../type-aliases/InjectionToken.md)\<`unknown`\>[]; `onError?`: `$InferOuterFunctionType`\<`ZodTuple`\<\[`ZodCustom`\<`Error`, `Error`\>, `ZodType`\<[`ContainerInterface`](../interfaces/ContainerInterface.md), `unknown`, `$ZodTypeInternals`\<[`ContainerInterface`](../interfaces/ContainerInterface.md), `unknown`\>\>\], `null`\>, `ZodVoid`\>; `onExit?`: `$InferOuterFunctionType`\<`ZodTuple`\<\[`ZodNumber`, `ZodOptional`\<`ZodCustom`\<`Error`, `Error`\>\>, `ZodType`\<[`ContainerInterface`](../interfaces/ContainerInterface.md), `unknown`, `$ZodTypeInternals`\<[`ContainerInterface`](../interfaces/ContainerInterface.md), `unknown`\>\>\], `null`\>, `ZodVoid`\>; `pretty`: `boolean`; \} = `CliOptionsSchema`
 
 ###### options.commandDefinitions?
 
@@ -64,6 +64,10 @@ App configuration and options.
 ###### options.container?
 
 [`ContainerInterface`](../interfaces/ContainerInterface.md) = `...`
+
+###### options.logErrors
+
+`boolean` = `...`
 
 ###### options.logger?
 
@@ -75,11 +79,11 @@ App configuration and options.
 
 ###### options.onError?
 
-`$InferOuterFunctionType`\<`ZodTuple`\<\[`ZodCustom`\<`Error`, `Error`\>\], `null`\>, `ZodVoid`\> = `...`
+`$InferOuterFunctionType`\<`ZodTuple`\<\[`ZodCustom`\<`Error`, `Error`\>, `ZodType`\<[`ContainerInterface`](../interfaces/ContainerInterface.md), `unknown`, `$ZodTypeInternals`\<[`ContainerInterface`](../interfaces/ContainerInterface.md), `unknown`\>\>\], `null`\>, `ZodVoid`\> = `...`
 
 ###### options.onExit?
 
-`$InferOuterFunctionType`\<`ZodTuple`\<\[`ZodNumber`, `ZodOptional`\<`ZodCustom`\<`Error`, `Error`\>\>\], `null`\>, `ZodVoid`\> = `...`
+`$InferOuterFunctionType`\<`ZodTuple`\<\[`ZodNumber`, `ZodOptional`\<`ZodCustom`\<`Error`, `Error`\>\>, `ZodType`\<[`ContainerInterface`](../interfaces/ContainerInterface.md), `unknown`, `$ZodTypeInternals`\<[`ContainerInterface`](../interfaces/ContainerInterface.md), `unknown`\>\>\], `null`\>, `ZodVoid`\> = `...`
 
 ###### options.pretty
 
@@ -167,7 +171,7 @@ Defined in: [CliApp.ts:25](https://github.com/axm-internal/axm-internals/blob/ma
 
 > `protected` **initialized**: `boolean` = `false`
 
-Defined in: [CliApp.ts:28](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L28)
+Defined in: [CliApp.ts:29](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L29)
 
 ***
 
@@ -175,7 +179,15 @@ Defined in: [CliApp.ts:28](https://github.com/axm-internal/axm-internals/blob/ma
 
 > `protected` `optional` **lastError**: `Error`
 
-Defined in: [CliApp.ts:29](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L29)
+Defined in: [CliApp.ts:30](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L30)
+
+***
+
+### logErrors
+
+> `protected` **logErrors**: `boolean`
+
+Defined in: [CliApp.ts:28](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L28)
 
 ***
 
@@ -189,15 +201,19 @@ Defined in: [CliApp.ts:27](https://github.com/axm-internal/axm-internals/blob/ma
 
 ### onError()?
 
-> `protected` `optional` **onError**: (`error`) => `void`
+> `protected` `optional` **onError**: (`error`, `container`) => `void`
 
-Defined in: [CliApp.ts:30](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L30)
+Defined in: [CliApp.ts:31](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L31)
 
 #### Parameters
 
 ##### error
 
 `Error`
+
+##### container
+
+[`ContainerInterface`](../interfaces/ContainerInterface.md)
 
 #### Returns
 
@@ -207,9 +223,9 @@ Defined in: [CliApp.ts:30](https://github.com/axm-internal/axm-internals/blob/ma
 
 ### onExit()?
 
-> `protected` `optional` **onExit**: (`code`, `error?`) => `void`
+> `protected` `optional` **onExit**: (`code`, `error`, `container`) => `void`
 
-Defined in: [CliApp.ts:31](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L31)
+Defined in: [CliApp.ts:32](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L32)
 
 #### Parameters
 
@@ -217,9 +233,13 @@ Defined in: [CliApp.ts:31](https://github.com/axm-internal/axm-internals/blob/ma
 
 `number`
 
-##### error?
+##### error
 
-`Error`
+`Error` | `undefined`
+
+##### container
+
+[`ContainerInterface`](../interfaces/ContainerInterface.md)
 
 #### Returns
 
@@ -239,7 +259,7 @@ Defined in: [CliApp.ts:23](https://github.com/axm-internal/axm-internals/blob/ma
 
 > **addCommand**(`commandDefinition`): `void`
 
-Defined in: [CliApp.ts:141](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L141)
+Defined in: [CliApp.ts:152](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L152)
 
 Add a command definition to the app.
 
@@ -295,7 +315,7 @@ app.addCommand(definition);
 
 > **clearLastError**(): `void`
 
-Defined in: [CliApp.ts:109](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L109)
+Defined in: [CliApp.ts:120](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L120)
 
 Clear the stored last error.
 
@@ -321,7 +341,7 @@ app.clearLastError();
 
 > `protected` **createLogger**(`appName`, `pretty`, `baseLogger?`): `Logger`
 
-Defined in: [CliApp.ts:62](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L62)
+Defined in: [CliApp.ts:73](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L73)
 
 #### Parameters
 
@@ -347,7 +367,7 @@ Defined in: [CliApp.ts:62](https://github.com/axm-internal/axm-internals/blob/ma
 
 > **getLastError**(): `Error` \| `undefined`
 
-Defined in: [CliApp.ts:94](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L94)
+Defined in: [CliApp.ts:105](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L105)
 
 Get the last error captured during execution.
 
@@ -373,7 +393,7 @@ const lastError = app.getLastError();
 
 > **getProgram**(): `Command`
 
-Defined in: [CliApp.ts:79](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L79)
+Defined in: [CliApp.ts:90](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L90)
 
 Access the underlying Commander program instance.
 
@@ -400,7 +420,7 @@ program.showHelpAfterError();
 
 > `protected` **init**(): `void`
 
-Defined in: [CliApp.ts:153](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L153)
+Defined in: [CliApp.ts:164](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L164)
 
 #### Returns
 
@@ -412,7 +432,7 @@ Defined in: [CliApp.ts:153](https://github.com/axm-internal/axm-internals/blob/m
 
 > `protected` **registerCommand**(`commandDefinition`): `void`
 
-Defined in: [CliApp.ts:145](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L145)
+Defined in: [CliApp.ts:156](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L156)
 
 #### Parameters
 
@@ -452,7 +472,7 @@ Defined in: [CliApp.ts:145](https://github.com/axm-internal/axm-internals/blob/m
 
 > **setCommands**(`commandDefinitions`): `void`
 
-Defined in: [CliApp.ts:125](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L125)
+Defined in: [CliApp.ts:136](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L136)
 
 Replace the command definitions for the app.
 
@@ -486,7 +506,7 @@ app.setCommands([definition]);
 
 > **start**(): `Promise`\<`number`\>
 
-Defined in: [CliApp.ts:191](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L191)
+Defined in: [CliApp.ts:202](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/CliApp.ts#L202)
 
 Initialize and run the CLI.
 

--- a/packages/cli-kit/docs/functions/createCommandDefinition.md
+++ b/packages/cli-kit/docs/functions/createCommandDefinition.md
@@ -6,13 +6,17 @@
 
 # Function: createCommandDefinition()
 
-> **createCommandDefinition**\<`ArgsSchema`, `OptionsSchema`\>(`definition`): `object`
+> **createCommandDefinition**\<`TContainer`, `ArgsSchema`, `OptionsSchema`\>(`definition`): `object`
 
-Defined in: [createCommandDefinition.ts:42](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L42)
+Defined in: [createCommandDefinition.ts:43](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L43)
 
 Create a strongly-typed command definition.
 
 ## Type Parameters
+
+### TContainer
+
+`TContainer` = [`ContainerInterface`](../interfaces/ContainerInterface.md)
 
 ### ArgsSchema
 

--- a/packages/cli-kit/docs/interfaces/ContainerInterface.md
+++ b/packages/cli-kit/docs/interfaces/ContainerInterface.md
@@ -6,7 +6,7 @@
 
 # Interface: ContainerInterface
 
-Defined in: [interfaces/ContainerInterface.ts:41](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/interfaces/ContainerInterface.ts#L41)
+Defined in: [interfaces/ContainerInterface.ts:43](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/interfaces/ContainerInterface.ts#L43)
 
 Minimal dependency injection container interface.
 
@@ -27,7 +27,7 @@ container.registerInstance('Logger', console);
 
 > **registerInstance**\<`T`\>(`token`, `instance`): `ContainerInterface`
 
-Defined in: [interfaces/ContainerInterface.ts:55](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/interfaces/ContainerInterface.ts#L55)
+Defined in: [interfaces/ContainerInterface.ts:57](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/interfaces/ContainerInterface.ts#L57)
 
 Register a concrete instance for a token.
 
@@ -73,7 +73,7 @@ container.registerInstance('Logger', console);
 
 > **resolve**\<`T`\>(`token`): `T`
 
-Defined in: [interfaces/ContainerInterface.ts:68](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/interfaces/ContainerInterface.ts#L68)
+Defined in: [interfaces/ContainerInterface.ts:70](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/interfaces/ContainerInterface.ts#L70)
 
 Resolve a previously registered instance.
 

--- a/packages/cli-kit/docs/type-aliases/CliAppParams.md
+++ b/packages/cli-kit/docs/type-aliases/CliAppParams.md
@@ -8,4 +8,4 @@
 
 > **CliAppParams** = `z.infer`\<*typeof* `CliAppParamsSchema`\>
 
-Defined in: [schemas/CliAppSchemas.ts:72](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/schemas/CliAppSchemas.ts#L72)
+Defined in: [schemas/CliAppSchemas.ts:73](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/schemas/CliAppSchemas.ts#L73)

--- a/packages/cli-kit/docs/type-aliases/CliConfig.md
+++ b/packages/cli-kit/docs/type-aliases/CliConfig.md
@@ -8,4 +8,4 @@
 
 > **CliConfig** = `z.infer`\<*typeof* `CliConfigSchema`\>
 
-Defined in: [schemas/CliAppSchemas.ts:70](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/schemas/CliAppSchemas.ts#L70)
+Defined in: [schemas/CliAppSchemas.ts:71](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/schemas/CliAppSchemas.ts#L71)

--- a/packages/cli-kit/docs/type-aliases/CliOptions.md
+++ b/packages/cli-kit/docs/type-aliases/CliOptions.md
@@ -8,4 +8,4 @@
 
 > **CliOptions** = `z.infer`\<*typeof* `CliOptionsSchema`\>
 
-Defined in: [schemas/CliAppSchemas.ts:71](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/schemas/CliAppSchemas.ts#L71)
+Defined in: [schemas/CliAppSchemas.ts:72](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/schemas/CliAppSchemas.ts#L72)

--- a/packages/cli-kit/docs/type-aliases/CommandContextForSchemas.md
+++ b/packages/cli-kit/docs/type-aliases/CommandContextForSchemas.md
@@ -4,9 +4,9 @@
 
 [@axm-internal/cli-kit](../globals.md) / CommandContextForSchemas
 
-# Type Alias: CommandContextForSchemas\<ArgsSchema, OptionsSchema\>
+# Type Alias: CommandContextForSchemas\<ArgsSchema, OptionsSchema, TContainer\>
 
-> **CommandContextForSchemas**\<`ArgsSchema`, `OptionsSchema`\> = `object`
+> **CommandContextForSchemas**\<`ArgsSchema`, `OptionsSchema`, `TContainer`\> = `object`
 
 Defined in: [createCommandDefinition.ts:15](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L15)
 
@@ -32,21 +32,25 @@ type Ctx = CommandContextForSchemas<typeof argsSchema, typeof optionsSchema>;
 
 `OptionsSchema` *extends* `z.ZodObject`\<`z.ZodRawShape`\>
 
+### TContainer
+
+`TContainer` = [`ContainerInterface`](../interfaces/ContainerInterface.md)
+
 ## Properties
 
 ### args
 
 > **args**: `z.infer`\<`ArgsSchema`\>
 
-Defined in: [createCommandDefinition.ts:19](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L19)
+Defined in: [createCommandDefinition.ts:20](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L20)
 
 ***
 
 ### container
 
-> **container**: [`ContainerInterface`](../interfaces/ContainerInterface.md)
+> **container**: `TContainer`
 
-Defined in: [createCommandDefinition.ts:21](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L21)
+Defined in: [createCommandDefinition.ts:22](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L22)
 
 ***
 
@@ -54,4 +58,4 @@ Defined in: [createCommandDefinition.ts:21](https://github.com/axm-internal/axm-
 
 > **options**: `z.infer`\<`OptionsSchema`\>
 
-Defined in: [createCommandDefinition.ts:20](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L20)
+Defined in: [createCommandDefinition.ts:21](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/createCommandDefinition.ts#L21)

--- a/packages/cli-kit/docs/type-aliases/InjectionToken.md
+++ b/packages/cli-kit/docs/type-aliases/InjectionToken.md
@@ -8,7 +8,7 @@
 
 > **InjectionToken**\<`T`\> = (...`args`) => `T` \| `string` \| `symbol`
 
-Defined in: [interfaces/ContainerInterface.ts:13](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/interfaces/ContainerInterface.ts#L13)
+Defined in: [interfaces/ContainerInterface.ts:15](https://github.com/axm-internal/axm-internals/blob/main/packages/cli-kit/src/interfaces/ContainerInterface.ts#L15)
 
 Token used to register and resolve values from a container.
 

--- a/packages/cli-kit/src/CliApp.ts
+++ b/packages/cli-kit/src/CliApp.ts
@@ -25,6 +25,7 @@ export class CliApp {
     protected container: ContainerInterface;
     protected commandDefinitions: CommandDefinition[];
     protected logger: Logger;
+    protected logErrors: boolean;
     protected initialized = false;
     protected lastError?: Error;
     protected onError?: (error: Error, container: ContainerInterface) => void;
@@ -44,12 +45,22 @@ export class CliApp {
      */
     constructor(params: CliAppParams) {
         const { config, options } = CliAppParamsSchema.parse(params);
-        const { commandDefinitions = [], container, logger, loggerAliases, pretty = true, onError, onExit } = options;
+        const {
+            commandDefinitions = [],
+            container,
+            logger,
+            loggerAliases,
+            pretty = true,
+            logErrors = true,
+            onError,
+            onExit,
+        } = options;
 
         this.config = config;
         this.commandDefinitions = commandDefinitions;
         this.container = container ?? new InMemoryContainer();
         this.logger = this.createLogger(config.name, pretty, logger);
+        this.logErrors = logErrors;
         this.onError = onError;
         this.onExit = onExit;
         const tokens = [CliLogger, ...(loggerAliases ?? [])];
@@ -224,7 +235,9 @@ export class CliApp {
 
             this.lastError = normalizedError;
             this.onError?.(normalizedError, this.container);
-            logger.error(error, '❌ CLI Error:');
+            if (this.logErrors) {
+                logger.error(error, '❌ CLI Error:');
+            }
             this.onExit?.(1, normalizedError, this.container);
             return 1;
         }

--- a/packages/cli-kit/src/schemas/CliAppSchemas.ts
+++ b/packages/cli-kit/src/schemas/CliAppSchemas.ts
@@ -33,6 +33,7 @@ export const CliConfigSchema = z.object({
 /** @internal */
 export const CliOptionsSchema = z.object({
     pretty: z.boolean().default(true),
+    logErrors: z.boolean().default(true),
     container: ContainerSchema.optional(),
     commandDefinitions: z.array(CommandDefinitionSchema).optional(),
     logger: PinoInstanceSchema.optional(),

--- a/packages/git-db/src/cli/index.ts
+++ b/packages/git-db/src/cli/index.ts
@@ -16,6 +16,7 @@ const cliApp = new CliApp({
     options: {
         logger: logger,
         pretty: true,
+        logErrors: false,
         commandDefinitions: [initCommand, updateCommand, queryCommand],
         onError: (error) => {
             if (error instanceof ZodError) {


### PR DESCRIPTION
- added logErrors option to CliApp and schemas
- skipped logger.error when logErrors is false
- updated cli-kit docs and examples
- set logErrors false in git-db and repo-cli CLIs
- added test for logErrors behavior

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a logErrors option to CliApp so CLIs can suppress default error logging when they handle errors themselves. repo-cli and git-db now disable default logging to avoid duplicate error output.

- **New Features**
  - Added options.logErrors (default true) to CliApp and schema; skips logger.error when false.
  - Updated docs and examples to show how and when to set logErrors.
  - Added unit test covering suppressed logging behavior.
  - Set logErrors: false in repo-cli and git-db.

- **Dependencies**
  - Bumped Biome schema to 2.3.14.

<sup>Written for commit c2e4144927ef7595fc598149441c3ee42eb5fc11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

