### PR TITLE
Feat/migration npm plan

### DIFF
--- a/monorepo-docs/migration-docs/monorepo-docs-cleanup.md
+++ b/monorepo-docs/migration-docs/monorepo-docs-cleanup.md
@@ -1,0 +1,104 @@
+# monorepo-docs Cleanup
+
+## Goal
+
+Consolidate and clean up `monorepo-docs/` so it serves as a clear, non-redundant reference.
+
+## Current Structure
+
+```
+monorepo-docs/
+  archived/
+    back-log.md
+    changeset-scripts.md       ← stale (changeset removal pending)
+    config-schema.md            ← stale (package exists, docs live in package)
+    git-db-plan.md              ← stale (package exists, docs live in package)
+    hono-kit-plan.md            ← stale (package exists, docs live in package)
+    hono-server-wrapper.md      ← stale (superseded by hono-kit)
+    intro-to-changesets.md      ← stale (changeset removal pending)
+    overview.md                 ← outdated (AGENTS.md replaces this)
+  feat/
+    BunQueue-package.md          ← active (pre-implementation spec)
+    cli-runner.md                ← verify: still relevant?
+    code-quality-review-pipeline.md
+  prompts/
+    llms-txt-generator.md
+    typedoc-docblocks.md
+  conventions.md                 ← canonical
+  package-checklist.md           ← canonical
+  release-versioning-pipeline.md ← rewrite after changesets removal
+```
+
+## Problems
+
+1. **`archived/` is a graveyard** — 7 files, most are stale. Two will be moot after changesets removal.
+2. **`release-versioning-pipeline.md`** is entirely about changesets — must be rewritten.
+3. **`feat/` has no clear criteria** — when does a spec become a package? Should it move after implementation?
+4. **`overview.md` in archived** overlaps heavily with `AGENTS.md`.
+5. **`conventions.md`** overlaps with `AGENTS.md` and `CLAUDE.md`.
+
+## Proposed Structure
+
+```
+monorepo-docs/
+  conventions.md              ← keep (authoritative)
+  package-checklist.md         ← keep (authoritative)
+  release-pipeline.md          ← rename + rewrite (no changesets)
+  feat/
+    BunQueue-package.md         ← keep (active spec)
+    cli-runner.md               ← keep or archive after review
+    code-quality-review-pipeline.md  ← keep
+  prompts/
+    llms-txt-generator.md       ← keep
+    typedoc-docblocks.md        ← keep
+  migration-docs/
+    npm-registry.md             ← keep (new)
+    remove-changesets.md         ← keep (new)
+    monorepo-docs-cleanup.md    ← this file, delete after execution
+```
+
+## Actions
+
+### Delete
+
+| File | Reason |
+|------|--------|
+| `archived/changeset-scripts.md` | Moot after changesets removal |
+| `archived/intro-to-changesets.md` | Moot after changesets removal |
+| `archived/overview.md` | Replaced by AGENTS.md |
+| `archived/config-schema.md` | Package has its own docs |
+| `archived/git-db-plan.md` | Package has its own docs |
+| `archived/hono-kit-plan.md` | Package has its own docs |
+| `archived/hono-server-wrapper.md` | Superseded by hono-kit |
+| `archived/back-log.md` | Stale backlog, no value |
+| `release-versioning-pipeline.md` | Replaced by `release-pipeline.md` |
+
+### Rename + Rewrite
+
+| From | To | Change |
+|------|----|--------|
+| `release-versioning-pipeline.md` | `release-pipeline.md` | Rewrite without changesets |
+
+### Review
+
+| File | Question |
+|------|----------|
+| `feat/cli-runner.md` | Is this still an active spec or has it been implemented? |
+
+### Keep As-Is
+
+- `conventions.md` — canonical reference
+- `package-checklist.md` — canonical reference
+- `feat/BunQueue-package.md` — active spec
+- `feat/code-quality-review-pipeline.md` — active reference
+- `prompts/*` — active Codex skills
+- `migration-docs/npm-registry.md` — new
+- `migration-docs/remove-changesets.md` — new
+
+## Execution Order
+
+1. Delete `archived/` contents (or the whole directory)
+2. Rewrite `release-versioning-pipeline.md` → `release-pipeline.md`
+3. Update `AGENTS.md` and `CLAUDE.md` to reference `release-pipeline.md` instead of `release-versioning-pipeline.md`
+4. Review `feat/cli-runner.md` — archive if implemented
+5. Delete this file (`monorepo-docs-cleanup.md`) after cleanup is done

--- a/monorepo-docs/migration-docs/npm-registry.md
+++ b/monorepo-docs/migration-docs/npm-registry.md
@@ -1,0 +1,111 @@
+# NPM Registry Migration
+
+## Goal
+
+Publish `@axm-internal/*` packages to the npm public registry instead of GitHub Packages.
+
+## Why
+
+GitHub Packages requires auth for every install, scoping friction with registries, and no real benefit for internal tooling that will go public. npmjs.com is the default registry — zero config for consumers.
+
+## Current State
+
+- Registry: `https://npm.pkg.github.com`
+- Auth: `.npmrc` with `GITHUB_TOKEN`
+- Scope: `@axm-internal`
+- Visibility: `restricted` (changeset config)
+- Publish: `changesets/action` in `.github/workflows/release.yml`
+
+## Required Changes
+
+### 1. `.npmrc` — switch registry
+
+**Before:**
+```
+@axm-internal:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+**After:**
+```
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
+```
+
+Remove the `@axm-internal:registry=` line — npmjs.com is the default, so scoped registry override is unnecessary.
+
+### 2. `package.json` — every publishable package
+
+Remove `publishConfig.registry` from each `packages/*/package.json`:
+
+```diff
+- "publishConfig": {
+-   "registry": "https://npm.pkg.github.com"
+- }
+```
+
+Or replace it with npmjs.com access if you want explicit config:
+
+```json
+"publishConfig": {
+  "access": "public"
+}
+```
+
+`@axm-internal` is a scoped package. On npmjs.com, scoped packages default to restricted visibility. You **must** set `"access": "public"` or publishes will succeed but installs will 403 for unauthenticated users.
+
+### 3. `.changeset/config.json` — open visibility
+
+```diff
+- "access": "restricted",
++ "access": "public",
+```
+
+### 4. GitHub secrets — add `NPM_TOKEN`
+
+1. Create an npm automation token: https://www.npmjs.com/settings/tokens/create (type: **Automation**)
+2. Add `NPM_TOKEN` as a repository secret: Settings > Secrets and variables > Actions > New repository secret
+
+### 5. `.github/workflows/release.yml` — update publish step
+
+Replace `GITHUB_TOKEN` with `NPM_TOKEN`:
+
+```diff
+  env:
+-   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
++   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+If keeping changesets/action:
+
+```yaml
+- uses: changesets/action@v1
+  with:
+    version: bunx changeset version
+    publish: bunx changeset publish
+  env:
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+If replacing changesets (see `remove-changesets.md`), use `bun publish` instead.
+
+### 6. Clean up GitHub Packages
+
+After migration, existing versions on `npm.pkg.github.com` remain. Options:
+
+- **Leave them** — they become stale; consumers switch to npmjs.com
+- **Deprecate them** — `npm deprecate @axm-internal/<pkg>@<version> "Moved to npmjs.com"` per version
+- **Delete the package** — via GitHub UI (destructive, irreversible)
+
+Recommendation: deprecate each package on GitHub Packages once the first npmjs.com publish lands.
+
+## Migration Order
+
+1. Create `NPM_TOKEN` and add to GitHub secrets
+2. Update `.npmrc`
+3. Update all `package.json` publish configs
+4. Update `.changeset/config.json` access
+5. Update workflow files
+6. Test publish with a single dry-run: `bun publish --dry-run` from a package dir
+7. Publish a patch version of one package manually to verify
+8. Deprecate GitHub Packages versions
+9. Update `AGENTS.md`, `CLAUDE.md`, and `monorepo-docs/conventions.md` to reflect new registry

--- a/monorepo-docs/migration-docs/release-cli-solution.md
+++ b/monorepo-docs/migration-docs/release-cli-solution.md
@@ -1,0 +1,370 @@
+# Release CLI: Dependency Cleanup & Ultimate Solution
+
+## Overview
+
+This document covers two phases:
+1. **Cleanup** — fix dependency issues across repo-cli, git-db, cli-kit, schema-orm, and shared utilities
+2. **Ultimate solution** — design a dedicated release CLI that replaces changesets entirely
+
+---
+
+## Phase 1: Dependency Audit & Cleanup
+
+### New Package: `@axm-internal/cli-tools`
+
+Shared CLI utilities currently duplicated between repo-cli and git-db. Lives in `packages/cli-tools/` following canonical package shape.
+
+**Contents:**
+- `renderJson` — currently deep-imported from git-db internals and duplicated
+- `buildCliTable` — currently duplicated across repo-cli and git-db
+- `truncateString` — currently duplicated
+- `formatDate` — currently internal to git-db, needed publicly
+
+**Depended on by:** git-db, repo-cli, release-cli (future), any other CLI app.
+
+**Why not `axm-shared`?** `axm-shared` becomes a junk drawer. `cli-tools` is scoped — CLI formatting and output utilities. `tooling-config` keeps its role as config-only (biome, remark, dup, commitlint).
+
+### repo-cli (`apps/repo-cli`)
+
+#### Issues Found
+
+| Issue | Severity | Detail |
+|-------|----------|--------|
+| Deep import from git-db | **High** | `InteractiveOutputService` imports `renderJson` from `@axm-internal/git-db/src/utils/dataRenderer` — internal path, not public API. |
+| Direct Kysely coupling | **High** | `GitQuery` writes raw `db.selectFrom('commits')` queries bypassing git-db's query layer. Implicit contract with git-db's schema. |
+| Unused dependency: `ora` | Low | Listed in `package.json` but never imported. Uses `yocto-spinner` instead. |
+| Duplicate utilities | Medium | `buildCliTable` and `truncateString` exist in both repo-cli and git-db. |
+| tsyringe + reflect-metadata | Medium | Heavy DI for a small app. cli-kit has `InMemoryContainer`. NovaDI is a lighter alternative. |
+
+#### Cleanup Actions
+
+1. **Move shared utilities to `@axm-internal/cli-tools`** — `renderJson`, `buildCliTable`, `truncateString`, `formatDate`
+2. **Replace deep import** of `renderJson` with `@axm-internal/cli-tools` import
+3. **Move raw Kysely queries into git-db** — GitQuery's direct `db.selectFrom()` calls should become proper query functions in git-db
+4. **Remove `ora`** from `package.json`
+5. **Remove duplicate utilities** — import from `@axm-internal/cli-tools` instead
+6. **Replace tsyringe** with NovaDI or InMemoryContainer (see DI section below)
+7. **Remove `ChangeSetBuilder`, `ChangeSetWriter`, `changesets:create`** command after release-cli is operational
+
+### git-db (`packages/git-db`)
+
+#### Current State
+
+- Purely functional API — `openBunDb()`, `scanCommits()`, `findCommitsByScope()`, etc.
+- Uses Kysely for query building
+- Uses execa for `git log` and `git show`
+- Has its own CLI (`init`, `update`, `query`)
+- `findCommitsByPackage` is path-prefix only (no scope+path JOIN)
+
+#### Kysely vs Drizzle Assessment
+
+git-db currently uses Kysely. Should it switch to Drizzle (via schema-orm)?
+
+| Capability | Kysely | Drizzle (via schema-orm) | Status |
+|-----------|--------|--------------------------|--------|
+| JOINs | First-class, composable | Not in schema-orm Model; available via drizzle escape hatch | Need escape hatch |
+| WHERE operators | Full SQL (LIKE, IN, BETWEEN, raw) | Equality only in schema-orm; full SQL via drizzle escape hatch | Need escape hatch |
+| Foreign keys | Supported | Not in schema-orm DDL | Need to add |
+| Composite PKs | Supported | Declared but unused in schema-orm | Need to implement |
+| onConflict/upsert | Supported | Read-then-write (not atomic) | Need to fix |
+| Async | Native | schema-orm is sync-only | git-db needs async |
+| Composability | Excellent (chain any clause) | Limited by schema-orm Model | Escape hatch needed |
+| Type safety | Full (prevents invalid JOINs) | Full on single-table; escape hatch loses some | Acceptable |
+
+**Verdict:** Do not replace Kysely in git-db. Instead, **enhance schema-orm with the missing features** and add a drizzle escape hatch. git-db stays on Kysely for now (it works well), but when schema-orm gains the features, git-db can optionally migrate.
+
+**The highest-ROI move for schema-orm:** expose the drizzle `db` instance and table objects via `getDrizzleDb()` and `getModelTable()`. This immediately unlocks JOINs, advanced WHERE, onConflict, and everything else drizzle supports, without reimplementing.
+
+#### git-db Programmatic API
+
+git-db already exports functions for programmatic use. The gap is that tag queries, topological ranges, and scope+path JOINs only exist in repo-cli's `GitQuery`. Moving those into git-db makes it a complete programmatic toolkit.
+
+#### Issues Found
+
+| Issue | Severity | Detail |
+|-------|----------|--------|
+| Missing tag/release queries | Medium | No API for listing tags, resolving tag-to-commit, or topological commit ranges. GitQuery fills this with execa. |
+| `findCommitsByPackage` is naive | Medium | Just path-prefix matching. Doesn't combine scope + file path. |
+| `renderJson` deep-imported | Medium | Not part of public API; used by repo-cli via internal path. |
+| Duplicate CLI utilities | Medium | `buildCliTable`, `truncateString` also in repo-cli. |
+
+#### Cleanup Actions
+
+1. **Add tag queries** — `listTags(scope?)`, `getLatestTag(scope)`, `resolveTag(tag)` → moves execa `git tag` calls from GitQuery
+2. **Add topological range queries** — `getCommitsBetweenRefs(fromRef, toRef, scope?)` → moves `git rev-list` calls
+3. **Upgrade `findCommitsByPackage`** — combine scope + file-path matching (the JOIN GitQuery does manually)
+4. **Move shared utilities to `@axm-internal/cli-tools`** — `renderJson`, `buildCliTable`, `truncateString`, `formatDate`
+5. **Keep Kysely** for now — works well, no reason to switch until schema-orm catches up
+
+### cli-kit (`packages/cli-kit`)
+
+#### Current State
+
+- Provides `CliApp`, `createCommandDefinition`, `CliOutputService`, `InMemoryContainer`
+- Container-agnostic (tsyringe is a peer dep, not used internally)
+- Commander.js under the hood
+- Zod-based arg/option validation with auto-help
+
+#### Issues Found
+
+| Issue | Severity | Detail |
+|-------|----------|--------|
+| Minimal output service | Medium | Only `log`, `logSuccess`, `logError`. No warning, spinner, table, or progress. |
+| No interactive prompting | Medium | No confirm, select, or text input. |
+| No dry-run mechanism | Low | Only `--debug`. No `--dry-run` pattern. |
+
+#### Cleanup Actions
+
+1. **Add `logWarning`** to `CliOutputService` (yellow, stderr)
+2. **Add dry-run support** — `dryRun` flag in `CommandContext`, propagated from `--dry-run` global option on `CliApp`
+3. **Consider spinner support** — `startSpinner`/`stopSpinner` on `CliOutputService`
+4. **Consider prompt primitives** — `confirm()`, `select()` as optional utilities
+
+### schema-orm (`packages/schema-orm`)
+
+#### Current State
+
+- Zod-schema-driven ORM on top of drizzle-orm
+- Supports bun:sqlite, better-sqlite3, expo-sqlite
+- Auto-generates tables from Zod schemas
+- CRUD operations via `Model` class
+- **Not used** by git-db or repo-cli (they use Kysely directly)
+
+#### Feature Gap Analysis
+
+| Feature | Status | Effort | Implementation Path |
+|---------|--------|--------|---------------------|
+| JOIN support | Missing | Low (escape hatch) / High (full API) | Expose `getDrizzleDb()` + `getModelTable()` for immediate access. Full relational API later. |
+| Foreign keys | Missing | Medium | Add `references` to `ColumnMetaSchema`, DDL generation, two-pass table construction in drizzle adapter |
+| Composite PKs | Declared but unused | Low-Medium | `TableSpec.compositePrimaryKeys` exists but is dead code. Implement DDL + drizzle adapter. |
+| Advanced WHERE | Equality only | Medium | Replace `Where<T> = Partial<T>` with operator objects (`{ like: string }`, `{ in: T[] }`, etc.) |
+| onConflict/upsert | Read-then-write (not atomic) | Low | Rewrite using drizzle's `onConflictDoUpdate()`. Single atomic statement. |
+| Async support | Sync only | High | Consider separate async package. Not needed for current use case. |
+
+#### Recommended Implementation Order for schema-orm
+
+1. **Drizzle escape hatch** (low effort, highest ROI) — `getDrizzleDb()` on the return value of `defineDatabase`, `getTable()` on `Model`. This immediately unlocks JOINs, all WHERE operators, onConflict, subqueries — everything drizzle supports.
+2. **onConflict upsert** (low effort) — rewrite `Model.upsert()` to use drizzle's `.onConflictDoUpdate()`. Single atomic statement instead of 3 queries.
+3. **Composite primary keys** (low-medium effort) — the `TableSpec.compositePrimaryKeys` field already exists. Implement DDL generation and drizzle adapter.
+4. **Advanced WHERE operators** (medium effort) — operator objects in `Where<T>` with `buildWhere()` pattern matching.
+5. **Foreign key support** (medium effort) — `references` in `ColumnMetaSchema`, DDL generation, two-pass table construction.
+6. **Async support** (high effort) — separate package or generic `Model<TSchema, TMode>`.
+
+### DI Container: Replacing tsyringe
+
+tsyringe requires `reflect-metadata` and decorators. Two better options:
+
+| Option | Decorators | reflect-metadata | Size | Autowiring |
+|--------|-----------|------------------|------|------------|
+| **NovaDI** (`@novadi/core`) | No | No | 3.9KB | Yes (fluent builder) |
+| **InMemoryContainer** (cli-kit) | No | No | Already in tree | No (manual `registerInstance`/`resolve`) |
+
+**Recommendation:** Start with expanding cli-kit's `InMemoryContainer`. It's already in the tree, has zero deps, and the apps are small. If autowiring becomes necessary, migrate to NovaDI. No reason to carry tsyringe + reflect-metadata.
+
+---
+
+## Phase 2: Ultimate Release Solution
+
+### Design Principles
+
+- **Per-package by default**, batch only for initial push or shared lib updates
+- **Manual trigger first**, automate later
+- **Conventional commits drive semver** — no extra markdown files
+- **repo-cli changelog system stays** — it already does correct per-package attribution (commit scope + changed files)
+- **GitQuery capabilities move into git-db** — tag queries, topological ranges, scope+path JOINs
+- **No external versioning tool** — release-cli handles bumping, tagging, and publishing natively
+
+### Why Not bumpx?
+
+bumpx was evaluated. It does the "lazy way" for changelogs — one root `CHANGELOG.md` from git log, no per-package attribution. The existing `repo-cli` changelog system (`.changelogs/*.json` → `changelog:update` → `changelog:write`) does the "correct way" — it matches commits to packages by scope + file paths. bumpx would replace version bumping but we'd still need our own changelog logic. Since we're building release-cli anyway, bumping is trivial to include.
+
+### New App: `apps/release-cli`
+
+A dedicated CLI tool for versioning, publishing, and release orchestration. Separate from repo-cli (which handles changelogs, git-db indexing, and prompt runners).
+
+#### Architecture
+
+```
+apps/release-cli/
+  src/
+    index.ts
+    commands/
+      version.ts          # bump a package's version
+      tag.ts               # create git tags for released packages
+      publish.ts           # publish to npm registry
+      release.ts           # full orchestration: index → changelog → version → tag → publish
+    services/
+      VersionService.ts   # semver bumping, package.json mutation
+      TagService.ts        # git tag creation/push
+      PublishService.ts    # bun publish orchestration
+      ReleaseService.ts    # orchestrates the full flow
+```
+
+#### Dependencies
+
+| Package | Usage |
+|---------|-------|
+| `@axm-internal/cli-kit` | CliApp, createCommandDefinition, CliOutputService |
+| `@axm-internal/cli-tools` | renderJson, buildCliTable |
+| `@axm-internal/git-db` | openBunDb, scanCommits, tag queries, commit range queries |
+| `zod` | Command arg/option schemas |
+| `execa` | git tag, git push, bun publish |
+
+No tsyringe. Use cli-kit's `InMemoryContainer` or NovaDI.
+
+#### Commands
+
+**`release-cli version <package> [patch|minor|major]`**
+
+1. Read current version from `packages/<pkg>/package.json`
+2. Apply semver bump
+3. If `--cascade`, bump internal deps that reference this package (patch bump)
+4. Write updated `package.json` files
+5. `--dry-run` to preview without writing
+
+**`release-cli tag <package>`**
+
+1. Read the current version from `packages/<pkg>/package.json`
+2. Create annotated git tag: `@axm-internal/<pkg>@<version>`
+3. `--push` to push tags to remote
+4. `--dry-run` to preview
+
+**`release-cli publish <package>`**
+
+1. `cd packages/<pkg> && bun publish --access public`
+2. `--dry-run` to preview
+3. `--all` to publish all publishable packages (for initial push)
+4. `--tag <dist-tag>` for prerelease channels
+
+**`release-cli release <package> [patch|minor|major]`**
+
+Full orchestration:
+1. `git-db:index` (ensure commit index is fresh)
+2. `repo-cli changelog:update <pkg>` (append new entries)
+3. `repo-cli changelog:write <pkg>` (render markdown)
+4. `release-cli version <pkg> <bump>` (bump version)
+5. `release-cli tag <pkg>` (create tag)
+6. Git commit all changes
+7. `release-cli publish <pkg>` (publish to npm)
+8. `--dry-run` to preview the entire flow
+9. `--skip-publish` to do everything except publish
+
+#### git-db New Functions (from Phase 1 cleanup)
+
+```typescript
+// Tag queries (currently in GitQuery via execa)
+listTags(scope?: string): Promise<TagInfo[]>
+getLatestTag(scope: string): Promise<TagInfo | null>
+resolveTag(tagName: string): Promise<string> // returns commit hash
+
+// Topological range queries (currently in GitQuery via execa)
+getCommitsBetweenRefs(fromRef: string, toRef: string, scope?: string): Promise<Commit[]>
+
+// Combined scope + path query (currently a manual JOIN in GitQuery)
+findCommitsByScopeAndPath(scope: string, pathPrefix: string, fromHash?: string, toHash?: string): Promise<Commit[]>
+```
+
+#### repo-cli Changes (after cleanup)
+
+- `GitQuery` becomes thinner — delegates to git-db for tag and range queries
+- Remove `ChangeSetBuilder`, `ChangeSetWriter`, and `changesets:create` command
+- Remove tsyringe + reflect-metadata
+- Keep all `changelog:*` and `gitdb:*` commands
+- Keep `prompt:*` commands (or move to their own tool later)
+
+#### Release Workflow (CI)
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Package to release"
+        required: true
+      bump:
+        description: "Version bump"
+        required: true
+        default: "patch"
+        type: choice
+        options: [patch, minor, major]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run validate
+      - run: bun run release-cli release ${{ inputs.package }} ${{ inputs.bump }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+Single workflow, single command. Manual trigger with package + bump type. Automate later by detecting conventional commit types.
+
+---
+
+## Execution Order
+
+### Step 1: Create `@axm-internal/cli-tools`
+1. `bun create axm-package packages/cli-tools`
+2. Move `renderJson`, `buildCliTable`, `truncateString`, `formatDate` into it
+3. Export from `src/index.ts`
+4. Update git-db and repo-cli to import from `@axm-internal/cli-tools`
+
+### Step 2: Clean up git-db
+1. Add tag query functions
+2. Add topological range query functions
+3. Upgrade `findCommitsByPackage` with scope + path JOIN
+4. Export `renderJson` etc. from `@axm-internal/cli-tools` (not deep paths)
+
+### Step 3: Enhance schema-orm
+1. Add drizzle escape hatch (`getDrizzleDb()`, `getTable()`)
+2. Rewrite `upsert()` to use drizzle's `onConflictDoUpdate()`
+3. Implement composite primary keys (already partially scaffolded)
+4. Add advanced WHERE operators (operator objects)
+5. Add foreign key support to DDL and schema
+
+### Step 4: Clean up repo-cli
+1. Replace deep import of `renderJson` with `@axm-internal/cli-tools`
+2. Replace raw Kysely queries in GitQuery with git-db function calls
+3. Remove `ora` from package.json
+4. Remove duplicate utilities (use `@axm-internal/cli-tools`)
+5. Replace tsyringe with InMemoryContainer (or NovaDI)
+6. Remove `ChangeSetBuilder`, `ChangeSetWriter`, `changesets:create` command
+
+### Step 5: Clean up cli-kit
+1. Add `logWarning` to CliOutputService
+2. Add dry-run support to CommandContext
+
+### Step 6: Create release-cli
+1. Scaffold with `bun create axm-package` → `apps/release-cli`
+2. Implement `VersionService` + `version` command
+3. Implement `TagService` + `tag` command
+4. Implement `PublishService` + `publish` command
+5. Implement `ReleaseService` + `release` command (orchestration)
+
+### Step 7: Remove changesets
+1. Remove `@changesets/cli` from root package.json
+2. Delete `.changeset/`, `.changeset-drafts/`, `.release/`
+3. Remove `release-pr.yml` workflow
+4. Rewrite `release.yml` to use release-cli
+
+### Step 8: Migrate to npmjs.com
+1. Follow steps in `npm-registry.md`
+2. Update all publish configs to `"access": "public"`
+3. Update `.npmrc` to use `NPM_TOKEN`
+4. Test with a single package
+5. Deprecate GitHub Packages
+
+### Step 9: Clean up monorepo-docs
+1. Follow steps in `monorepo-docs-cleanup.md`
+2. Rewrite release docs
+3. Update AGENTS.md and CLAUDE.md

--- a/monorepo-docs/migration-docs/remove-changesets.md
+++ b/monorepo-docs/migration-docs/remove-changesets.md
@@ -1,0 +1,147 @@
+# Remove Changesets
+
+## Goal
+
+Remove `@changesets/cli` and all changeset infrastructure. Replace with a simpler, Bun-native versioning and publishing workflow.
+
+## Why
+
+Changesets is over-engineered for this repo:
+- Extra markdown files for every change (`.changeset/*.md`)
+- A whole CI gating mechanism (`.release/ready`) just to trigger a publish
+- `changesets/action` is a heavy GitHub Action that versions, commits, and publishes in one shot
+- The repo already has `repo-cli` generating JSON changelogs — changeset changelogs are unused (`changelog: false` in config)
+- Two-step release dance (release PR, then publish) adds friction for a small internal monorepo
+
+## What Changesets Currently Does
+
+1. **Version bumping** — reads `.changeset/*.md`, bumps `package.json` versions
+2. **Publishing** — runs `npm publish` per package
+3. **Release gating** — `.release/ready` marker triggers the publish workflow
+4. **Changelog generation** — disabled (`"changelog": false`); repo uses `repo-cli changelog:write` instead
+
+## Replacement: `bun publish` + `repo-cli`
+
+### Version Bumping
+
+Use `repo-cli` or a simple script to bump versions. No markdown files needed — decide the bump type and run it.
+
+Add a new `repo-cli` command (or standalone script):
+
+```bash
+# Bump a single package
+./repo-cli version <package> <patch|minor|major>
+
+# Bump all packages with changes
+./repo-cli version --all <patch|minor|major>
+```
+
+This updates `package.json` versions and optionally writes changelog entries.
+
+### Publishing
+
+Replace `changesets/action` with a direct `bun publish` step:
+
+```yaml
+- name: Publish packages
+  run: |
+    for pkg in packages/*/; do
+      if [ -f "$pkg/package.json" ]; then
+        cd "$pkg"
+        bun publish --access public
+        cd -
+      fi
+    done
+  env:
+    NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+```
+
+Or use `repo-cli` to orchestrate:
+
+```bash
+./repo-cli publish --all
+```
+
+### Release Workflow
+
+Replace the two-workflow dance (release-pr.yml + release.yml) with a single workflow:
+
+```yaml
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        default: "patch"
+        type: choice
+        options: [patch, minor, major]
+      packages:
+        description: "Packages to release (comma-separated, or 'all')"
+        required: true
+        default: "all"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install
+      - run: bun run validate
+      - run: ./repo-cli version ${{ inputs.packages }} ${{ inputs.bump }}
+      - run: ./repo-cli changelog:update --all
+      - run: ./repo-cli changelog:write --all
+      - run: ./repo-cli publish --all
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore(release): published packages"
+          git push
+```
+
+## Files to Remove
+
+| Path | Reason |
+|------|--------|
+| `.changeset/config.json` | Changeset configuration |
+| `.changeset/*.md` | All changeset files (if any exist) |
+| `.changeset-drafts/` | Draft changesets |
+| `.release/` | Release marker directory |
+| `monorepo-docs/release-versioning-pipeline.md` | Changeset-specific docs |
+| `monorepo-docs/archived/intro-to-changesets.md` | Already archived |
+| `monorepo-docs/archived/changeset-scripts.md` | Already archived |
+
+## Files to Modify
+
+| Path | Change |
+|------|--------|
+| `package.json` | Remove `@changesets/cli` from devDependencies |
+| `.github/workflows/release.yml` | Replace changesets/action with bun publish |
+| `.github/workflows/release-pr.yml` | Simplify or merge into release.yml |
+| `AGENTS.md` | Remove changeset references, update release pipeline docs |
+| `CLAUDE.md` | Remove changeset commands, update release pipeline |
+| `monorepo-docs/conventions.md` | Remove changeset versioning references |
+| `apps/repo-cli/src/commands/changesets/` | Remove changeset-specific commands |
+| `apps/repo-cli/src/services/ChangeSetBuilder.ts` | Remove |
+| `apps/repo-cli/src/services/ChangeSetWriter.ts` | Remove |
+
+## Migration Order
+
+1. Add `repo-cli version` and `repo-cli publish` commands
+2. Add `NPM_TOKEN` secret to GitHub (see `npm-registry.md`)
+3. Update release workflow to use `bun publish` + `repo-cli`
+4. Remove release-pr workflow (no longer needed)
+5. Test: manually trigger release workflow with a patch bump
+6. Remove `@changesets/cli` from root `package.json`
+7. Delete `.changeset/`, `.changeset-drafts/`, `.release/`
+8. Remove changeset-related repo-cli code
+9. Update all docs
+10. Remove changeset-related archived docs

--- a/monorepo-docs/migration-docs/remove-changesets.md
+++ b/monorepo-docs/migration-docs/remove-changesets.md
@@ -47,6 +47,11 @@ Replace `changesets/action` with a direct `bun publish` step:
   run: |
     for pkg in packages/*/; do
       if [ -f "$pkg/package.json" ]; then
+        private=$(node -e "console.log(require('$pkg/package.json').private || false)")
+        if [ "$private" = "true" ]; then
+          echo "Skipping private package: $pkg"
+          continue
+        fi
         cd "$pkg"
         bun publish --access public
         cd -


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds detailed migration docs to move `@axm-internal/*` to npm, remove Changesets, and design a new per‑package release CLI. The plan emphasizes targeted releases (no mass publish) and a docs cleanup to simplify the pipeline.

- **Migration**
  - Added `monorepo-docs/migration-docs/*`: `npm-registry.md`, `remove-changesets.md`, `release-cli-solution.md`, and a `monorepo-docs-cleanup.md` plan.
  - Switch to npm: update `.npmrc`, set `"access": "public"` in each package, add `NPM_TOKEN`, and change CI to use `bun publish`.
  - Remove Changesets and simplify CI: drop `@changesets/cli`, delete `.changeset/*` and release PR flow, and consolidate into a single manual Release workflow.
  - Release CLI design: new `apps/release-cli` with `version`, `tag`, `publish`, and `release`; uses `@axm-internal/cli-kit`, new `@axm-internal/cli-tools`, and `@axm-internal/git-db`; `repo-cli` keeps changelog generation.
  - Tooling cleanup: create `@axm-internal/cli-tools`; move git tag/range queries into `@axm-internal/git-db`; add `cli-kit` warnings and `--dry-run`; prefer its container over `tsyringe`.
  - Docs hygiene and scope: rewrite `release-versioning-pipeline.md` to `release-pipeline.md`, prune `archived/`, update `AGENTS.md`/`CLAUDE.md`; default to per‑package releases and avoid publishing all packages at once (bulk only for initial push if ever).

<sup>Written for commit e709592bf0f4e2a0c58407c60ed821a250e98ae3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

