### PR TITLE
feat(schema-orm): added escape hatch, upsert, composite PKs, WHERE ops, FKs

### DIFF
--- a/packages/schema-orm/src/db/Model.ts
+++ b/packages/schema-orm/src/db/Model.ts
@@ -1,8 +1,28 @@
-import { and, asc, desc, eq, type SQL, sql } from 'drizzle-orm';
+import {
+    and,
+    asc,
+    between,
+    desc,
+    eq,
+    gt,
+    gte,
+    inArray,
+    isNotNull,
+    isNull as isNullSql,
+    like,
+    lt,
+    lte,
+    ne,
+    notBetween,
+    notInArray,
+    notLike,
+    type SQL,
+    sql,
+} from 'drizzle-orm';
 import type { AnySQLiteTable } from 'drizzle-orm/sqlite-core';
 import { getTableColumns } from 'drizzle-orm/utils';
 import { z } from 'zod';
-import { getPrimaryKeyField, isAutoIncrement, isNullable } from '../schema/meta';
+import { getPrimaryKeyFields, isAutoIncrement, isNullable } from '../schema/meta';
 import { PaginationQuerySchema, WriteOptionsSchema } from '../schema/schemas';
 import { modelConfigToDrizzleTable } from '../sql/dml/drizzle-adapter';
 import type {
@@ -28,7 +48,7 @@ export type ModelParams<TSchema extends z.ZodObject<z.ZodRawShape>> = {
 type ModelData<TSchema extends z.ZodObject<z.ZodRawShape>> = z.infer<TSchema>;
 
 type FindByIdParams = {
-    id: string | number;
+    id: string | number | Record<string, unknown>;
 };
 
 type FindOneParams<TSchema extends z.ZodObject<z.ZodRawShape>> = {
@@ -83,7 +103,7 @@ type RemoveParams<TSchema extends z.ZodObject<z.ZodRawShape>> = {
 };
 
 export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
-    protected primaryKeyColumn: string | null;
+    protected primaryKeyColumns: string[];
     protected modelConfig: ModelConfigFor<TSchema>;
     protected sqliteTable: AnySQLiteTable;
     protected db: AnySQLiteDb;
@@ -133,18 +153,30 @@ export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
         this.db = db;
         this.modelConfig = modelConfig;
         this.sqliteTable = modelConfigToDrizzleTable(modelConfig);
-        this.primaryKeyColumn = getPrimaryKeyField(this.modelConfig.schema);
+        this.primaryKeyColumns = getPrimaryKeyFields(this.modelConfig.schema);
         this.columns = getTableColumns(this.sqliteTable);
     }
 
     findById({ id }: FindByIdParams): ModelData<TSchema> | null {
-        if (!this.primaryKeyColumn) {
+        if (this.primaryKeyColumns.length === 0) {
             return null;
         }
-        const where = this.buildWhere({ [this.primaryKeyColumn]: id } as Where<ModelData<TSchema>>);
+        let where: Record<string, unknown>;
+        if (typeof id === 'object' && id !== null) {
+            where = id;
+        } else {
+            if (this.primaryKeyColumns.length !== 1) {
+                throw new Error(
+                    'findById with a scalar id requires a single primary key column; use object id for composite keys'
+                );
+            }
+            const pkField = this.primaryKeyColumns[0] as string;
+            where = { [pkField]: id };
+        }
+        const whereSql = this.buildWhere(where as Where<ModelData<TSchema>>);
         const query = this.selectFromTable();
-        if (where) {
-            query.where(where);
+        if (whereSql) {
+            query.where(whereSql);
         }
         query.limit(1);
         return (query.get() as ModelData<TSchema> | undefined) ?? null;
@@ -237,12 +269,30 @@ export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
     }
 
     upsert({ where, data, validate }: UpsertParams<TSchema>): ModelData<TSchema> {
-        const existing = this.findOne({ where });
-        if (existing) {
-            this.update({ where, data: data as Partial<ModelData<TSchema>>, validate });
-            return this.findOne({ where }) as ModelData<TSchema>;
+        const parsed = this.validateInsert(data as Record<string, unknown>, validate);
+        const whereEntries = Object.entries(where as Record<string, unknown>);
+        const mergedData = { ...Object.fromEntries(whereEntries), ...parsed };
+        const conflictFields = whereEntries.length > 0 ? whereEntries.map(([key]) => key) : this.primaryKeyColumns;
+        const conflictColumns = conflictFields
+            .map((key) => this.columns[key])
+            .filter((col): col is NonNullable<typeof col> => col !== undefined);
+        const conflictFieldSet = new Set(conflictFields);
+        const updateSet: Record<string, unknown> = {};
+        for (const [key, value] of Object.entries(mergedData)) {
+            if (!conflictFieldSet.has(key)) {
+                updateSet[key] = value;
+            }
         }
-        return this.save({ data, validate });
+        const result = this.db
+            .insert(this.sqliteTable)
+            .values(mergedData)
+            .onConflictDoUpdate({
+                target: conflictColumns,
+                set: updateSet as Record<string, unknown>,
+            })
+            .returning()
+            .get();
+        return result as ModelData<TSchema>;
     }
 
     remove({ where }: RemoveParams<TSchema>): number {
@@ -259,6 +309,14 @@ export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
 
     removeMany({ where }: RemoveParams<TSchema>): number {
         return this.remove({ where });
+    }
+
+    getDrizzleDb(): AnySQLiteDb {
+        return this.db;
+    }
+
+    getTable(): AnySQLiteTable {
+        return this.sqliteTable;
     }
 
     private validateInsert<TInput extends Record<string, unknown>>(data: TInput, validate?: InsertOptions['validate']) {
@@ -330,9 +388,37 @@ export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
             if (!column) {
                 throw new Error(`Unknown column "${field}" for table "${this.modelConfig.table}"`);
             }
-            return eq(column, value as never);
+            return this.buildWhereClause(column, value);
         });
-        return clauses.length === 1 ? clauses[0] : and(...clauses);
+        return clauses.length === 1 ? (clauses[0] as SQL) : and(...clauses);
+    }
+
+    private buildWhereClause(column: ReturnType<typeof getTableColumns>[string], value: unknown): SQL {
+        if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
+            return eq(column, value as never);
+        }
+        if ('eq' in value) return eq(column, (value as { eq: unknown }).eq as never);
+        if ('ne' in value) return ne(column, (value as { ne: unknown }).ne as never);
+        if ('gt' in value) return gt(column, (value as { gt: unknown }).gt as never);
+        if ('gte' in value) return gte(column, (value as { gte: unknown }).gte as never);
+        if ('lt' in value) return lt(column, (value as { lt: unknown }).lt as never);
+        if ('lte' in value) return lte(column, (value as { lte: unknown }).lte as never);
+        if ('like' in value) return like(column, (value as { like: string }).like);
+        if ('notLike' in value) return notLike(column, (value as { notLike: string }).notLike);
+        if ('in' in value) return inArray(column, (value as { in: unknown[] }).in as never[]);
+        if ('notIn' in value) return notInArray(column, (value as { notIn: unknown[] }).notIn as never[]);
+        if ('isNull' in value) {
+            return (value as { isNull: boolean }).isNull ? isNullSql(column) : isNotNull(column);
+        }
+        if ('between' in value) {
+            const [min, max] = (value as { between: [unknown, unknown] }).between;
+            return between(column, min as never, max as never);
+        }
+        if ('notBetween' in value) {
+            const [min, max] = (value as { notBetween: [unknown, unknown] }).notBetween;
+            return notBetween(column, min as never, max as never);
+        }
+        return eq(column, value as never);
     }
 
     private buildOrderBy(orderBy?: OrderBy<ModelData<TSchema>>): SQL[] | undefined {

--- a/packages/schema-orm/src/db/Model.ts
+++ b/packages/schema-orm/src/db/Model.ts
@@ -271,7 +271,8 @@ export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
     upsert({ where, data, validate }: UpsertParams<TSchema>): ModelData<TSchema> {
         const parsed = this.validateInsert(data as Record<string, unknown>, validate);
         const whereEntries = Object.entries(where as Record<string, unknown>);
-        const mergedData = { ...Object.fromEntries(whereEntries), ...parsed };
+        const whereValues = whereEntries.map(([key, val]) => [key, extractWhereValue(val)] as [string, unknown]);
+        const mergedData = { ...Object.fromEntries(whereValues), ...parsed };
         const conflictFields = whereEntries.length > 0 ? whereEntries.map(([key]) => key) : this.primaryKeyColumns;
         const conflictColumns = conflictFields
             .map((key) => this.columns[key])
@@ -394,7 +395,10 @@ export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
     }
 
     private buildWhereClause(column: ReturnType<typeof getTableColumns>[string], value: unknown): SQL {
-        if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
+        if (value === null) {
+            return isNullSql(column);
+        }
+        if (value === undefined || typeof value !== 'object' || Array.isArray(value)) {
             return eq(column, value as never);
         }
         if ('eq' in value) return eq(column, (value as { eq: unknown }).eq as never);
@@ -405,8 +409,16 @@ export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
         if ('lte' in value) return lte(column, (value as { lte: unknown }).lte as never);
         if ('like' in value) return like(column, (value as { like: string }).like);
         if ('notLike' in value) return notLike(column, (value as { notLike: string }).notLike);
-        if ('in' in value) return inArray(column, (value as { in: unknown[] }).in as never[]);
-        if ('notIn' in value) return notInArray(column, (value as { notIn: unknown[] }).notIn as never[]);
+        if ('in' in value) {
+            const values = (value as { in: unknown[] }).in;
+            if (values.length === 0) return sql`1 = 0`;
+            return inArray(column, values as never[]);
+        }
+        if ('notIn' in value) {
+            const values = (value as { notIn: unknown[] }).notIn;
+            if (values.length === 0) return sql`1 = 1`;
+            return notInArray(column, values as never[]);
+        }
         if ('isNull' in value) {
             return (value as { isNull: boolean }).isNull ? isNullSql(column) : isNotNull(column);
         }
@@ -434,3 +446,11 @@ export class Model<TSchema extends z.ZodObject<z.ZodRawShape>> {
         });
     }
 }
+
+const extractWhereValue = (value: unknown): unknown => {
+    if (value === null || value === undefined || typeof value !== 'object' || Array.isArray(value)) {
+        return value;
+    }
+    if ('eq' in value) return (value as { eq: unknown }).eq;
+    return value;
+};

--- a/packages/schema-orm/src/index.ts
+++ b/packages/schema-orm/src/index.ts
@@ -1,6 +1,11 @@
 export { defineDatabase } from './db/defineDatabase';
+export { Model } from './db/Model';
 export {
+    getForeignKey,
+    getPrimaryKeyFields,
+    isForeignKey,
     makeAutoIncrement,
+    makeForeignKey,
     makeJson,
     makePrimaryKey,
     makeUnique,
@@ -16,4 +21,5 @@ export type {
     PaginationQuery,
     UpdateOptions,
     Where,
+    WhereOperator,
 } from './types';

--- a/packages/schema-orm/src/schema/meta.ts
+++ b/packages/schema-orm/src/schema/meta.ts
@@ -76,6 +76,18 @@ export const isUnique = (schema: z.ZodType): boolean => {
     return getColumnMeta(schema).unique;
 };
 
+export const makeForeignKey = <T extends z.ZodType>(schema: T, config: { table: string; column: string }): T => {
+    return withDbMeta(schema, { references: { table: config.table, column: config.column } });
+};
+
+export const isForeignKey = (schema: z.ZodType): boolean => {
+    return getColumnMeta(schema).references !== undefined;
+};
+
+export const getForeignKey = (schema: z.ZodType): { table: string; column: string } | undefined => {
+    return getColumnMeta(schema).references;
+};
+
 export const isZodNullable = (schema: z.ZodType): schema is z.ZodNullable<z.ZodTypeAny> =>
     schema instanceof z.ZodNullable;
 
@@ -126,17 +138,18 @@ export const getDefault = (schema: z.ZodType): string | number | boolean | null 
     return (result.data === undefined ? null : result.data) as string | number | boolean | null;
 };
 
-export const getPrimaryKeyField = (schema: z.ZodType): string | null => {
+export const getPrimaryKeyFields = (schema: z.ZodType): string[] => {
     if (!(schema instanceof z.ZodObject)) {
-        return null;
+        return [];
     }
 
     const shape = schema.shape as Record<string, z.ZodType>;
-    for (const [fieldName, fieldSchema] of Object.entries(shape)) {
-        if (isPrimaryKey(fieldSchema)) {
-            return fieldName;
-        }
-    }
+    return Object.entries(shape)
+        .filter(([, fieldSchema]) => isPrimaryKey(fieldSchema))
+        .map(([fieldName]) => fieldName);
+};
 
-    return null;
+export const getPrimaryKeyField = (schema: z.ZodType): string | null => {
+    const fields = getPrimaryKeyFields(schema);
+    return fields.length > 0 ? (fields[0] as string) : null;
 };

--- a/packages/schema-orm/src/schema/schemas.ts
+++ b/packages/schema-orm/src/schema/schemas.ts
@@ -103,5 +103,6 @@ export const ColumnMetaSchema = z
         autoincrement: z.boolean().default(false),
         unique: z.boolean().default(false),
         json: z.boolean().default(false),
+        references: z.object({ table: z.string(), column: z.string() }).optional(),
     })
     .strict();

--- a/packages/schema-orm/src/sql/ddl/TableSqlGenerator.ts
+++ b/packages/schema-orm/src/sql/ddl/TableSqlGenerator.ts
@@ -1,5 +1,14 @@
 import * as z from 'zod';
-import { getDefault, isAutoIncrement, isJsonColumn, isNullable, isPrimaryKey, isUnique } from '../../schema/meta';
+import {
+    getDefault,
+    getForeignKey,
+    getPrimaryKeyFields,
+    isAutoIncrement,
+    isJsonColumn,
+    isNullable,
+    isPrimaryKey,
+    isUnique,
+} from '../../schema/meta';
 import type { ModelConfig } from '../../types';
 
 export type ColumnType = 'INTEGER' | 'REAL' | 'TEXT' | 'BLOB' | 'NUMERIC';
@@ -15,6 +24,7 @@ export type ColumnSpec = {
     unique: boolean;
     isJson: boolean;
     default: string | number | boolean | null;
+    references?: { table: string; column: string };
 };
 
 export type TableSpec = {
@@ -95,6 +105,8 @@ export function modelConfigToTableSpec(modelConfig: ModelConfig): TableSpec {
         columns: [],
     };
 
+    const pkFields = getPrimaryKeyFields(modelConfig.schema);
+
     for (const [columnName, columnSchema] of Object.entries(modelConfig.schema.shape)) {
         const columnSpecType = zodTypeToColumnSpecType(columnSchema);
         const columnSpec: ColumnSpec = {
@@ -107,21 +119,26 @@ export function modelConfigToTableSpec(modelConfig: ModelConfig): TableSpec {
             isJson: isJsonColumn(columnSchema),
             unique: isUnique(columnSchema),
             default: getDefault(columnSchema),
+            references: getForeignKey(columnSchema) ?? undefined,
         };
         tableSpec.columns.push(columnSpec);
+    }
+
+    if (pkFields.length > 1) {
+        tableSpec.compositePrimaryKeys = pkFields;
     }
 
     return tableSpec;
 }
 
-function columnSpecToString(columnSpec: ColumnSpec): string {
+function columnSpecToString(columnSpec: ColumnSpec, isPartOfCompositePK: boolean = false): string {
     const columnParts: string[] = [];
     columnParts.push(`"${columnSpec.name}"`);
     columnParts.push(`${columnSpec.type}`);
-    if (columnSpec.primaryKey) {
+    if (columnSpec.primaryKey && !isPartOfCompositePK) {
         columnParts.push('PRIMARY KEY');
     }
-    if (columnSpec.autoincrement && columnSpec.primaryKey && columnSpec.type === 'INTEGER') {
+    if (columnSpec.autoincrement && columnSpec.primaryKey && columnSpec.type === 'INTEGER' && !isPartOfCompositePK) {
         columnParts.push('AUTOINCREMENT');
     }
     if (columnSpec.notNull) {
@@ -138,13 +155,26 @@ function columnSpecToString(columnSpec: ColumnSpec): string {
             columnParts.push(`DEFAULT ${columnSpec.default}`);
         }
     }
+    if (columnSpec.references) {
+        columnParts.push(`REFERENCES "${columnSpec.references.table}" ("${columnSpec.references.column}")`);
+    }
 
     return columnParts.join(' ');
 }
 
 function tableSpecToCreateTable(tableSpec: TableSpec): string {
-    const columns = tableSpec.columns.map(columnSpecToString).join(', ');
-    return `CREATE TABLE IF NOT EXISTS "${tableSpec.table}" (${columns});`;
+    const compositePKSet = tableSpec.compositePrimaryKeys ? new Set(tableSpec.compositePrimaryKeys) : new Set<string>();
+
+    const columns = tableSpec.columns.map((col) => columnSpecToString(col, compositePKSet.has(col.name))).join(', ');
+
+    const constraints: string[] = [];
+    if (tableSpec.compositePrimaryKeys && tableSpec.compositePrimaryKeys.length > 1) {
+        const pkCols = tableSpec.compositePrimaryKeys.map((c) => `"${c}"`).join(', ');
+        constraints.push(`PRIMARY KEY (${pkCols})`);
+    }
+
+    const allParts = constraints.length > 0 ? `${columns}, ${constraints.join(', ')}` : columns;
+    return `CREATE TABLE IF NOT EXISTS "${tableSpec.table}" (${allParts});`;
 }
 
 export function generateCreateTable(modelConfig: ModelConfig): string {
@@ -164,8 +194,10 @@ export function tableSpecSignature(tableSpec: TableSpec): string {
                 notNull: column.notNull,
                 unique: column.unique,
                 default: column.default,
+                references: column.references ?? null,
             }))
             .sort((a, b) => a.name.localeCompare(b.name)),
+        compositePrimaryKeys: tableSpec.compositePrimaryKeys ?? [],
     };
 
     const json = JSON.stringify(normalized);

--- a/packages/schema-orm/src/sql/dml/drizzle-adapter.ts
+++ b/packages/schema-orm/src/sql/dml/drizzle-adapter.ts
@@ -86,7 +86,10 @@ const isOperatorObject = (value: unknown): value is WhereOperator<unknown> =>
     typeof value === 'object' && value !== null && !Array.isArray(value);
 
 const buildWhereClauseSql = (field: string, value: unknown): SQL => {
-    if (value === null || value === undefined || !isOperatorObject(value)) {
+    if (value === null) {
+        return sql`${sql.identifier(field)} IS NULL`;
+    }
+    if (value === undefined || !isOperatorObject(value)) {
         return sql`${sql.identifier(field)} = ${value}`;
     }
     if ('eq' in value) return sql`${sql.identifier(field)} = ${value.eq}`;
@@ -99,11 +102,17 @@ const buildWhereClauseSql = (field: string, value: unknown): SQL => {
     if ('notLike' in value) return sql`${sql.identifier(field)} NOT LIKE ${value.notLike}`;
     if ('in' in value) {
         const values = value.in as unknown[];
+        if (values.length === 0) {
+            return sql`1 = 0`;
+        }
         const items = values.map((v) => sql`${v}`);
         return sql`${sql.identifier(field)} IN (${sql.join(items, sql`, `)})`;
     }
     if ('notIn' in value) {
         const values = value.notIn as unknown[];
+        if (values.length === 0) {
+            return sql`1 = 1`;
+        }
         const items = values.map((v) => sql`${v}`);
         return sql`${sql.identifier(field)} NOT IN (${sql.join(items, sql`, `)})`;
     }

--- a/packages/schema-orm/src/sql/dml/drizzle-adapter.ts
+++ b/packages/schema-orm/src/sql/dml/drizzle-adapter.ts
@@ -1,7 +1,7 @@
 import { type SQL, sql } from 'drizzle-orm';
-import type { AnySQLiteTable } from 'drizzle-orm/sqlite-core';
-import { blob, integer, numeric, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
-import type { ModelConfig, OrderBy, PaginationQuery, Where } from '../../types';
+import type { AnySQLiteColumn, AnySQLiteTable } from 'drizzle-orm/sqlite-core';
+import { blob, integer, numeric, primaryKey, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import type { ModelConfig, OrderBy, PaginationQuery, Where, WhereOperator } from '../../types';
 import { type ColumnSpec, modelConfigToTableSpec, type TableSpec } from '../ddl/TableSqlGenerator';
 
 type ColumnBuilder =
@@ -11,7 +11,7 @@ type ColumnBuilder =
     | ReturnType<typeof blob>
     | ReturnType<typeof numeric>;
 
-const columnSpecToBuilder = (columnSpec: ColumnSpec): ColumnBuilder => {
+const columnSpecToBuilder = (columnSpec: ColumnSpec, compositePKSet?: Set<string>): ColumnBuilder => {
     let builder: ColumnBuilder;
 
     switch (columnSpec.type) {
@@ -39,7 +39,8 @@ const columnSpecToBuilder = (columnSpec: ColumnSpec): ColumnBuilder => {
             break;
     }
 
-    if (columnSpec.primaryKey) {
+    const isInCompositePK = compositePKSet?.has(columnSpec.name);
+    if (columnSpec.primaryKey && !isInCompositePK) {
         builder = builder.primaryKey({ autoIncrement: columnSpec.autoincrement });
     }
 
@@ -59,10 +60,18 @@ const columnSpecToBuilder = (columnSpec: ColumnSpec): ColumnBuilder => {
 };
 
 export const tableSpecToDrizzleTable = (tableSpec: TableSpec): AnySQLiteTable => {
+    const compositePKSet = tableSpec.compositePrimaryKeys ? new Set(tableSpec.compositePrimaryKeys) : undefined;
     const columns: Record<string, ColumnBuilder> = {};
 
     for (const columnSpec of tableSpec.columns) {
-        columns[columnSpec.name] = columnSpecToBuilder(columnSpec);
+        columns[columnSpec.name] = columnSpecToBuilder(columnSpec, compositePKSet);
+    }
+
+    if (tableSpec.compositePrimaryKeys && tableSpec.compositePrimaryKeys.length > 1) {
+        const pkNames = tableSpec.compositePrimaryKeys;
+        return sqliteTable(tableSpec.table, columns, (table) => [
+            primaryKey(...pkNames.map((name) => table[name] as AnySQLiteColumn)),
+        ]) as AnySQLiteTable;
     }
 
     return sqliteTable(tableSpec.table, columns);
@@ -73,12 +82,51 @@ export const modelConfigToDrizzleTable = (modelConfig: ModelConfig): AnySQLiteTa
     return tableSpecToDrizzleTable(tableSpec);
 };
 
+const isOperatorObject = (value: unknown): value is WhereOperator<unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const buildWhereClauseSql = (field: string, value: unknown): SQL => {
+    if (value === null || value === undefined || !isOperatorObject(value)) {
+        return sql`${sql.identifier(field)} = ${value}`;
+    }
+    if ('eq' in value) return sql`${sql.identifier(field)} = ${value.eq}`;
+    if ('ne' in value) return sql`${sql.identifier(field)} != ${value.ne}`;
+    if ('gt' in value) return sql`${sql.identifier(field)} > ${value.gt}`;
+    if ('gte' in value) return sql`${sql.identifier(field)} >= ${value.gte}`;
+    if ('lt' in value) return sql`${sql.identifier(field)} < ${value.lt}`;
+    if ('lte' in value) return sql`${sql.identifier(field)} <= ${value.lte}`;
+    if ('like' in value) return sql`${sql.identifier(field)} LIKE ${value.like}`;
+    if ('notLike' in value) return sql`${sql.identifier(field)} NOT LIKE ${value.notLike}`;
+    if ('in' in value) {
+        const values = value.in as unknown[];
+        const items = values.map((v) => sql`${v}`);
+        return sql`${sql.identifier(field)} IN (${sql.join(items, sql`, `)})`;
+    }
+    if ('notIn' in value) {
+        const values = value.notIn as unknown[];
+        const items = values.map((v) => sql`${v}`);
+        return sql`${sql.identifier(field)} NOT IN (${sql.join(items, sql`, `)})`;
+    }
+    if ('isNull' in value) {
+        return value.isNull ? sql`${sql.identifier(field)} IS NULL` : sql`${sql.identifier(field)} IS NOT NULL`;
+    }
+    if ('between' in value) {
+        const [min, max] = value.between as [unknown, unknown];
+        return sql`${sql.identifier(field)} BETWEEN ${min} AND ${max}`;
+    }
+    if ('notBetween' in value) {
+        const [min, max] = value.notBetween as [unknown, unknown];
+        return sql`${sql.identifier(field)} NOT BETWEEN ${min} AND ${max}`;
+    }
+    return sql`${sql.identifier(field)} = ${value}`;
+};
+
 const buildWhereSql = <T extends Record<string, unknown>>(where?: Where<T>): SQL | undefined => {
     if (!where || Object.keys(where).length === 0) {
         return undefined;
     }
-    const clauses = Object.entries(where).map(([field, value]) => sql`${sql.identifier(field)} = ${value}`);
-    return clauses.length === 1 ? clauses[0] : sql.join(clauses, sql` AND `);
+    const clauses = Object.entries(where).map(([field, value]) => buildWhereClauseSql(field, value));
+    return clauses.length === 1 ? (clauses[0] as SQL) : sql.join(clauses, sql` AND `);
 };
 
 const buildOrderBySql = <T extends Record<string, unknown>>(orderBy?: OrderBy<T>): SQL | undefined => {

--- a/packages/schema-orm/src/types.ts
+++ b/packages/schema-orm/src/types.ts
@@ -34,7 +34,24 @@ export type OrderBy<T extends Record<string, unknown>> = Array<{
     direction: 'asc' | 'desc';
 }>;
 
-export type Where<T extends Record<string, unknown>> = Partial<T>;
+export type WhereOperator<T> =
+    | { eq: T }
+    | { ne: T }
+    | { gt: T }
+    | { gte: T }
+    | { lt: T }
+    | { lte: T }
+    | { like: string }
+    | { notLike: string }
+    | { in: T[] }
+    | { notIn: T[] }
+    | { isNull: boolean }
+    | { between: [T, T] }
+    | { notBetween: [T, T] };
+
+export type Where<T extends Record<string, unknown>> = {
+    [K in keyof T]?: T[K] | WhereOperator<T[K]>;
+};
 
 export type FindAllOptions<T extends Record<string, unknown>> = {
     pagination?: PaginationQuery;

--- a/packages/schema-orm/tests/fixtures/index.ts
+++ b/packages/schema-orm/tests/fixtures/index.ts
@@ -1,5 +1,7 @@
+import { userRolesFixture } from './userRoles.fixtures';
 import { userModelFixture } from './users.fixtures';
 
 export const modelFixtures = {
     users: userModelFixture,
+    userRoles: userRolesFixture,
 };

--- a/packages/schema-orm/tests/fixtures/userRoles.fixtures.ts
+++ b/packages/schema-orm/tests/fixtures/userRoles.fixtures.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { makePrimaryKey } from '../../src/schema/meta';
+import type { ModelFixture } from './types';
+
+const schema = z.object({
+    userId: makePrimaryKey(z.number().int()),
+    roleId: makePrimaryKey(z.number().int()),
+    grantedAt: z.string(),
+});
+
+export const userRolesFixture: ModelFixture<typeof schema> = {
+    modelConfig: {
+        table: 'user_roles',
+        schema,
+    },
+    rows: [
+        { userId: 1, roleId: 10, grantedAt: '2024-01-01' },
+        { userId: 1, roleId: 20, grantedAt: '2024-01-02' },
+        { userId: 2, roleId: 10, grantedAt: '2024-01-03' },
+    ],
+};

--- a/packages/schema-orm/tests/integration/Model.test.ts
+++ b/packages/schema-orm/tests/integration/Model.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import { getTableColumns } from 'drizzle-orm/utils';
 import { z } from 'zod';
 import { getAdapterInstance } from '../../src/db/adapters/getAdapterInstance';
 import { defineDatabase } from '../../src/db/defineDatabase';
@@ -223,6 +224,139 @@ describe('Model (integration)', () => {
                     const removed = model.removeMany({ where: { name: 'Bob' } });
                     expect(removed).toBe(1);
                     expect(model.findById({ id: 2 })).toBeNull();
+                });
+            });
+
+            describe('advanced WHERE operators', () => {
+                it('filters with { gt } operator', () => {
+                    const rows = model.findMany({ where: { id: { gt: 1 } } });
+                    expect(rows.map((r) => r.name)).toEqual(['Bob', 'Cleo']);
+                });
+
+                it('filters with { lt } operator', () => {
+                    const rows = model.findMany({ where: { id: { lt: 3 } } });
+                    expect(rows.map((r) => r.name)).toEqual(['Ada', 'Bob']);
+                });
+
+                it('filters with { gte } operator', () => {
+                    const rows = model.findMany({ where: { id: { gte: 2 } } });
+                    expect(rows.map((r) => r.name)).toEqual(['Bob', 'Cleo']);
+                });
+
+                it('filters with { lte } operator', () => {
+                    const rows = model.findMany({ where: { id: { lte: 2 } } });
+                    expect(rows.map((r) => r.name)).toEqual(['Ada', 'Bob']);
+                });
+
+                it('filters with { ne } operator', () => {
+                    const rows = model.findMany({ where: { id: { ne: 2 } } });
+                    expect(rows.map((r) => r.name)).toEqual(['Ada', 'Cleo']);
+                });
+
+                it('filters with { like } operator', () => {
+                    const rows = model.findMany({ where: { name: { like: 'A%' } } });
+                    expect(rows.map((r) => r.name)).toEqual(['Ada']);
+                });
+
+                it('filters with { in } operator', () => {
+                    const rows = model.findMany({ where: { id: { in: [1, 3] } } });
+                    expect(rows.map((r) => r.name)).toEqual(['Ada', 'Cleo']);
+                });
+
+                it('filters with { between } operator', () => {
+                    const rows = model.findMany({ where: { id: { between: [1, 2] } } });
+                    expect(rows.map((r) => r.name)).toEqual(['Ada', 'Bob']);
+                });
+
+                it('combines plain values and operators', () => {
+                    const rows = model.findMany({
+                        where: { id: { gt: 1 }, name: { like: '%o%' } },
+                    });
+                    expect(rows.map((r) => r.name)).toEqual(['Bob', 'Cleo']);
+                });
+
+                it('plain values still work as equality (backward compat)', () => {
+                    const rows = model.findMany({ where: { name: 'Ada' } });
+                    expect(rows).toEqual([{ id: 1, name: 'Ada' }]);
+                });
+            });
+
+            describe('composite primary keys', () => {
+                type UserRoleSchema = typeof modelFixtures.userRoles.modelConfig.schema;
+                let userRolesModel: Model<UserRoleSchema>;
+
+                beforeAll(() => {
+                    const fixture = modelFixtures.userRoles;
+                    const adapterInstance = getAdapterInstance({
+                        adapter: 'bun-sqlite',
+                        databasePath: ':memory:',
+                        modelDefinitions: { userRoles: fixture.modelConfig },
+                        usePragmaPreset: false,
+                    });
+                    runner = adapterInstance.getSqlRunner();
+                    createTestTables(runner);
+                    seedTestTables(runner);
+                    userRolesModel = new Model<UserRoleSchema>({
+                        db: adapterInstance.getDrizzleDatabase(),
+                        modelConfig: fixture.modelConfig,
+                    });
+                });
+
+                it('findById with object id for composite PK', () => {
+                    const row = userRolesModel.findById({ id: { userId: 1, roleId: 10 } });
+                    expect(row).toEqual({ userId: 1, roleId: 10, grantedAt: '2024-01-01' });
+                });
+
+                it('findById throws for scalar id with composite PK', () => {
+                    expect(() => userRolesModel.findById({ id: 1 })).toThrow(
+                        'findById with a scalar id requires a single primary key column'
+                    );
+                });
+
+                it('findOne with composite PK where', () => {
+                    const row = userRolesModel.findOne({ where: { userId: 2, roleId: 10 } });
+                    expect(row).toEqual({ userId: 2, roleId: 10, grantedAt: '2024-01-03' });
+                });
+
+                it('remove with composite PK where', () => {
+                    const removed = userRolesModel.remove({ where: { userId: 1, roleId: 20 } });
+                    expect(removed).toBe(1);
+                    expect(userRolesModel.findById({ id: { userId: 1, roleId: 20 } })).toBeNull();
+                });
+
+                it('save inserts row with composite PK', () => {
+                    const row = userRolesModel.save({ data: { userId: 3, roleId: 30, grantedAt: '2024-02-01' } });
+                    expect(row).toEqual({ userId: 3, roleId: 30, grantedAt: '2024-02-01' });
+                });
+            });
+
+            describe('drizzle escape hatch', () => {
+                it('getDrizzleDb returns the underlying drizzle database', () => {
+                    const drizzleDb = model.getDrizzleDb();
+                    expect(drizzleDb).toBeDefined();
+                    expect(typeof drizzleDb.select).toBe('function');
+                    expect(typeof drizzleDb.insert).toBe('function');
+                    expect(typeof drizzleDb.update).toBe('function');
+                    expect(typeof drizzleDb.delete).toBe('function');
+                });
+
+                it('getTable returns the drizzle table object with column keys', () => {
+                    const table = model.getTable();
+                    expect(table).toBeDefined();
+                    const columns = getTableColumns(table);
+                    expect(Object.keys(columns)).toContain('id');
+                    expect(Object.keys(columns)).toContain('name');
+                });
+
+                it('can perform a raw drizzle query using escape hatch', () => {
+                    const drizzleDb = model.getDrizzleDb();
+                    const table = model.getTable();
+                    const rows = drizzleDb.select().from(table).all() as Array<{
+                        id: number;
+                        name: string;
+                    }>;
+                    const names = rows.map((r) => r.name).sort();
+                    expect(names).toEqual(['Ada', 'Bob', 'Cleo']);
                 });
             });
 

--- a/packages/schema-orm/tests/unit/meta.test.ts
+++ b/packages/schema-orm/tests/unit/meta.test.ts
@@ -3,8 +3,11 @@ import { z } from 'zod';
 import {
     getColumnMeta,
     getDefault,
+    getForeignKey,
     getPrimaryKeyField,
+    getPrimaryKeyFields,
     isAutoIncrement,
+    isForeignKey,
     isJsonColumn,
     isNullable,
     isPrimaryKey,
@@ -12,6 +15,7 @@ import {
     isZodNullable,
     isZodOptional,
     makeAutoIncrement,
+    makeForeignKey,
     makeJson,
     makePrimaryKey,
     makeUnique,
@@ -91,6 +95,32 @@ describe('meta helpers', () => {
         expect(isNullable(schema)).toBe(false);
     });
 
+    describe('foreign keys', () => {
+        it('makeForeignKey sets references metadata', () => {
+            const schema = makeForeignKey(z.number().int(), { table: 'users', column: 'id' });
+            const meta = getColumnMeta(schema);
+            expect(meta.references).toEqual({ table: 'users', column: 'id' });
+        });
+
+        it('isForeignKey returns true for foreign key columns', () => {
+            const schema = makeForeignKey(z.number().int(), { table: 'users', column: 'id' });
+            expect(isForeignKey(schema)).toBe(true);
+        });
+
+        it('isForeignKey returns false for non-FK columns', () => {
+            expect(isForeignKey(z.number().int())).toBe(false);
+        });
+
+        it('getForeignKey returns reference info', () => {
+            const schema = makeForeignKey(z.number().int(), { table: 'users', column: 'id' });
+            expect(getForeignKey(schema)).toEqual({ table: 'users', column: 'id' });
+        });
+
+        it('getForeignKey returns undefined for non-FK columns', () => {
+            expect(getForeignKey(z.number().int())).toBeUndefined();
+        });
+    });
+
     it('getPrimaryKeyField returns null for non-object schemas', () => {
         expect(getPrimaryKeyField(z.string())).toBeNull();
     });
@@ -108,6 +138,36 @@ describe('meta helpers', () => {
             name: z.string(),
         });
         expect(getPrimaryKeyField(schema)).toBeNull();
+    });
+
+    describe('getPrimaryKeyFields', () => {
+        it('returns empty array for non-object schemas', () => {
+            expect(getPrimaryKeyFields(z.string())).toEqual([]);
+        });
+
+        it('returns single-element array for single PK schema', () => {
+            const schema = z.object({
+                id: makePrimaryKey(z.number().int()),
+                name: z.string(),
+            });
+            expect(getPrimaryKeyFields(schema)).toEqual(['id']);
+        });
+
+        it('returns multi-element array for composite PK schema', () => {
+            const schema = z.object({
+                userId: makePrimaryKey(z.number().int()),
+                roleId: makePrimaryKey(z.number().int()),
+                grantedAt: z.string(),
+            });
+            expect(getPrimaryKeyFields(schema)).toEqual(['userId', 'roleId']);
+        });
+
+        it('returns empty array when no primary key is defined', () => {
+            const schema = z.object({
+                name: z.string(),
+            });
+            expect(getPrimaryKeyFields(schema)).toEqual([]);
+        });
     });
 });
 

--- a/packages/schema-orm/tests/unit/sql/table-sql-generator.test.ts
+++ b/packages/schema-orm/tests/unit/sql/table-sql-generator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { z } from 'zod';
-import { makeAutoIncrement, makeJson, makePrimaryKey, makeUnique } from '../../../src/schema/meta';
+import { makeAutoIncrement, makeForeignKey, makeJson, makePrimaryKey, makeUnique } from '../../../src/schema/meta';
 import { generateCreateTable } from '../../../src/sql/ddl/TableSqlGenerator';
 
 const UserSchema = z.object({
@@ -84,5 +84,61 @@ describe('TableSqlGenerator', () => {
             settings: z.object({ theme: z.string() }),
         });
         expect(() => generateCreateTable({ table: 'prefs', schema })).toThrow();
+    });
+
+    describe('composite primary keys', () => {
+        it('generates composite PRIMARY KEY constraint', () => {
+            const schema = z.object({
+                userId: makePrimaryKey(z.number().int()),
+                roleId: makePrimaryKey(z.number().int()),
+                grantedAt: z.string(),
+            });
+            const sql = generateCreateTable({ table: 'user_roles', schema });
+            expect(sql).toBe(
+                'CREATE TABLE IF NOT EXISTS "user_roles" ("userId" INTEGER NOT NULL, "roleId" INTEGER NOT NULL, "grantedAt" TEXT NOT NULL, PRIMARY KEY ("userId", "roleId"));'
+            );
+        });
+
+        it('does not add per-column PRIMARY KEY when in composite', () => {
+            const schema = z.object({
+                a: makePrimaryKey(z.number().int()),
+                b: makePrimaryKey(z.number().int()),
+            });
+            const sql = generateCreateTable({ table: 't', schema });
+            expect(sql).not.toContain('"a" INTEGER PRIMARY KEY');
+            expect(sql).not.toContain('"b" INTEGER PRIMARY KEY');
+            expect(sql).toContain('PRIMARY KEY ("a", "b")');
+        });
+
+        it('generates single PK as column constraint (not composite)', () => {
+            const schema = z.object({
+                id: makePrimaryKey(z.number().int()),
+                name: z.string(),
+            });
+            const sql = generateCreateTable({ table: 'single', schema });
+            expect(sql).toContain('"id" INTEGER PRIMARY KEY');
+            expect(sql).not.toContain('PRIMARY KEY (');
+        });
+    });
+
+    describe('foreign key references', () => {
+        it('generates REFERENCES clause for foreign key columns', () => {
+            const schema = z.object({
+                id: makeAutoIncrement(makePrimaryKey(z.number().int())),
+                userId: makeForeignKey(z.number().int(), { table: 'users', column: 'id' }),
+            });
+            const sql = generateCreateTable({ table: 'posts', schema });
+            expect(sql).toContain('REFERENCES "users" ("id")');
+        });
+
+        it('combines foreign key with other constraints', () => {
+            const schema = z.object({
+                id: makeAutoIncrement(makePrimaryKey(z.number().int())),
+                authorId: makeForeignKey(z.number().int(), { table: 'users', column: 'id' }),
+            });
+            const sql = generateCreateTable({ table: 'posts', schema });
+            expect(sql).toContain('NOT NULL');
+            expect(sql).toContain('REFERENCES "users" ("id")');
+        });
     });
 });


### PR DESCRIPTION
- Added `getDrizzleDb()` and `getTable()` escape hatch methods
  to Model class
- Exported `Model` class from public API for consumer
  type annotations
- Rewrote `upsert()` to use drizzle's `onConflictDoUpdate()`
  (single atomic statement instead of read-then-write)
- Added `getPrimaryKeyFields()` to meta module; refactored
  `getPrimaryKeyField()` to delegate
- Replaced `primaryKeyColumn: string | null` with
  `primaryKeyColumns: string[]` in Model
- Updated `findById()` to accept object id for composite
  primary keys
- Updated DDL generator to render `PRIMARY KEY (col1, col2)`
  table constraint for composite PKs
- Updated drizzle adapter to use `primaryKey()` constraint
  for composite PK tables
- Updated `tableSpecSignature()` to include
  `compositePrimaryKeys` in schema hash
- Replaced `Where<T> = Partial<T>` with operator-aware
  `Where<T>` type supporting `eq`, `ne`, `gt`, `gte`, `lt`,
  `lte`, `like`, `notLike`, `in`, `notIn`, `isNull`,
  `between`, `notBetween`
- Added `buildWhereClause()` method to Model for operator
  object detection
- Updated `buildWhereSql()` in drizzle-adapter for raw SQL
  operator support
- Added `makeForeignKey()`, `isForeignKey()`, `getForeignKey()`
  to meta module
- Added `references` field to `ColumnMetaSchema` for foreign
  key definitions
- Updated `ColumnSpec` type and DDL generator to render
  `REFERENCES "table" ("column")`
- Added `userRoles` fixture for composite PK integration tests
- Added 29 new tests across unit and integration suites
  (136 total, all passing)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds composite primary keys, foreign keys, operator-aware WHERE clauses, and atomic upserts to `schema-orm`, plus escape hatches to access `drizzle-orm` directly. Also fixes null and empty-array edge cases in WHERE, and improves upsert merging when using operators.

- New Features
  - Composite primary keys: `findById` accepts object ids; DDL renders `PRIMARY KEY (col1, col2)`; adapter uses `primaryKey()`; schema hash includes composite PKs.
  - WHERE operators: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `like`, `notLike`, `in`, `notIn`, `isNull`, `between`, `notBetween`; plain values still work as equality.
  - Upsert: single-statement `insert ... onConflictDoUpdate()` via `drizzle-orm`; conflict columns from `where` or PKs; returns the row.
  - Foreign keys: `makeForeignKey`, `isForeignKey`, `getForeignKey`; DDL emits `REFERENCES "table" ("column")`.
  - Escape hatch: `Model.getDrizzleDb()` and `Model.getTable()`; `Model` and `WhereOperator` exported from public API. Added composite PK fixtures and 29 tests.

- Bug Fixes
  - Upsert extracts raw values from `where` operator objects before merging.
  - WHERE builders use `IS NULL` for null comparisons.
  - Empty `in: []` and `notIn: []` generate valid SQL (`1 = 0` / `1 = 1`).

<sup>Written for commit c8e47c988df9f52d36607d0cdd416276d5064990. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

