### PR TITLE
chore(release-cli,repo): migrated registry to npmjs.com

### DIFF
--- a/.bun-create/README.md
+++ b/.bun-create/README.md
@@ -18,7 +18,7 @@ Notes:
 
 The `axm-package` template creates:
 
-- Canonical `package.json` (ESM, `src/index.ts`, GitHub Packages registry)
+- Canonical `package.json` (ESM, `src/index.ts`, public npm access)
 - `src/index.ts`
 - `tests/unit/example.test.ts`
 - `README.md`

--- a/.bun-create/axm-package/package.json
+++ b/.bun-create/axm-package/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "description": "__PACKAGE_DESC__",
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "access": "public"
     },
     "scripts": {
         "test": "bun test",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: write
-  packages: write
   pull-requests: write
 
 jobs:
@@ -30,4 +29,4 @@ jobs:
           ./repo-cli gitdb:index
           ./release-cli publish --all --push
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-@axm-internal:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ Use release-cli for per-package versions and publishing.
 Typical flow:
 
 1. Make changes.
-2. Run `bun run release-cli release <package> <bump>` locally.
+2. Run `bun run release-cli release <package-path> <bump>` locally.
 3. This bumps the version, updates changelogs, commits, tags, and publishes.
 4. Bulk publish via the GitHub Actions Release workflow (manual trigger only).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ packages/<name>/
   "type": "module",
   "main": "src/index.ts",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }
 ```
@@ -48,7 +48,7 @@ packages/<name>/
 See `monorepo-docs/package-checklist.md` before considering a package “dev complete.”
 
 - No build step. No `dist/`. TypeScript is consumed directly by Bun.
-- All packages are versioned and published via Changesets.
+- All packages are versioned and published via release-cli.
 
 ## Creating New Packages
 
@@ -109,7 +109,7 @@ Every package must provide:
 - `patch`: internal refactors, no behavior change
 - `minor`: new capability, backwards compatible
 - `major`: consumer code must change
-- Every meaningful change requires a Changeset.
+- Every meaningful change is released explicitly via release-cli.
 
 ## Promotion Policy
 
@@ -120,17 +120,16 @@ A package may be consumed by other projects only when:
 - It has at least one published version
 - Documentation requirements are met
 
-## Release & Versioning Pipeline (Changesets)
+## Release & Versioning Pipeline
 
-Use Changesets for per-package versions and publishing.
+Use release-cli for per-package versions and publishing.
 
 Typical flow:
 
 1. Make changes.
-2. Run `bunx changeset`.
-3. Commit the changeset with code.
-4. Merge to `main`.
-5. CI runs tests on every `main` push. Publishing via `changesets/action` only runs when `.release/ready` is present (set by the Release PR workflow); it versions packages, publishes, and removes the marker.
+2. Run `bun run release-cli release <package> <bump>` locally.
+3. This bumps the version, updates changelogs, commits, tags, and publishes.
+4. Bulk publish via the GitHub Actions Release workflow (manual trigger only).
 
 Changelogs are generated from `.changelogs/*.json` via `./repo-cli` and rendered with `changelog:write`.
 

--- a/README.md
+++ b/README.md
@@ -106,21 +106,12 @@ bun clean
 
 ## Package Installation
 
-`@axm-internal/*` packages are public and published to GitHub Packages. GitHub Packages
-still requires authentication for installs, so consumers must configure an auth token.
+`@axm-internal/*` packages are published to the public npm registry.
 
-Local setup (one-time):
-
-```bash
-echo "@axm-internal:registry=https://npm.pkg.github.com" >> ~/.npmrc
-echo "//npm.pkg.github.com/:_authToken=YOUR_GITHUB_TOKEN" >> ~/.npmrc
-```
-
-Then install as usual:
+Install as usual:
 
 ```bash
 bun add @axm-internal/zod-helpers
 ```
 
-CI setup should write the token to the repo `.npmrc` and include `packages: read`
-permissions for the workflow.
+No registry configuration is required for consumers.

--- a/monorepo-docs/conventions.md
+++ b/monorepo-docs/conventions.md
@@ -49,7 +49,7 @@ Rules:
   "type": "module",
   "main": "src/index.ts",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }
 ```

--- a/monorepo-docs/migration-docs/release-cli-checklist.md
+++ b/monorepo-docs/migration-docs/release-cli-checklist.md
@@ -65,11 +65,11 @@ Track progress for the release-cli migration. Check items off as completed.
 
 ### Step 8: Migrate to npmjs.com
 
-- [ ] 8.1 Follow steps in `npm-registry.md` — `chore/npmjs-migration`
-- [ ] 8.2 Update all publish configs to `"access": "public"` — (included above)
-- [ ] 8.3 Update `.npmrc` to use `NPM_TOKEN` — (included above)
-- [ ] 8.4 Test publish with a single package — (included above)
-- [ ] 8.5 Deprecate GitHub Packages — (included above)
+- [x] 8.1 Follow steps in `npm-registry.md` — `chore/npmjs-migration`
+- [x] 8.2 Update all publish configs to `"access": "public"` — (included above)
+- [x] 8.3 Update `.npmrc` to use `NPM_TOKEN` — (included above)
+- [ ] 8.4 Test publish with a single package — pending `NPM_TOKEN` secret
+- [ ] 8.5 Deprecate GitHub Packages — pending first npmjs.com publish
 
 ### Step 9: Clean up monorepo-docs
 

--- a/monorepo-docs/release-versioning-pipeline.md
+++ b/monorepo-docs/release-versioning-pipeline.md
@@ -124,14 +124,14 @@ This publishes every publishable package and pushes all release tags.
 
 ## Registry Integration
 
-Each package declares its registry:
+Each package declares public access:
 
 ```json
 {
   "name": "@axm-internal/cli-helper",
   "version": "0.1.0",
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }
 ```
@@ -139,11 +139,10 @@ Each package declares its registry:
 The repository includes an `.npmrc` for publishing:
 
 ```txt
-@axm-internal:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}
 ```
 
-GitHub Actions automatically provides `GITHUB_TOKEN`, enabling secure publishing without secrets.
+Add `NPM_TOKEN` as a repository secret under Settings > Secrets and variables > Actions.
 
 ---
 

--- a/monorepo-docs/todos.md
+++ b/monorepo-docs/todos.md
@@ -1,0 +1,55 @@
+❯ good. how do i generate a NPM_TOKEN. i am thinking zod-helpers is a good one to start with.
+
+⏺ Generating an NPM Token
+
+Option A: Web UI (recommended)
+
+1. Go to https://www.npmjs.com/settings/tokens
+2. Click Classic Token or Granular Access Token
+3. For Classic: select Automation (skips 2FA for CI)
+4. Copy the token immediately — npm shows it once
+
+Option B: CLI
+
+npm login                                                                                                                                                                                
+npm token create --read-only=false  # or npm access tokens:create
+
+Classic vs Granular:
+
+- Classic Automation — simpler, works everywhere, skips 2FA
+- Granular — fine-grained per-package access, requires npm Pro for org-scoped packages
+
+For @axm-internal/* (scoped org), you need either:
+- Classic token with access to the org
+- Granular token with Publish permission on @axm-internal/*
+
+If the @axm-internal org doesn't exist on npm yet, you'll need to create it first: https://www.npmjs.com/org/create
+                                                                                                                                                                                           
+---                                                                                                                                                                                      
+After You Have the Token
+
+For local test publish:
+
+export NPM_TOKEN=your_token_here                                                                                                                                                         
+cd packages/zod-helpers                                                                                                                                                                  
+bun publish --access public --dry-run
+
+Then actual release via release-cli:
+
+bun run release-cli release packages/zod-helpers patch --push
+
+This runs the full flow: index → changelog → version bump → commit → tag → publish.
+
+For CI (GitHub Actions):
+
+Add NPM_TOKEN as repository secret:                                                                                                                                                      
+Settings → Secrets and variables → Actions → New repository secret
+                                                                                                                                                                                           
+---                                                                                                                                                                                      
+zod-helpers Status
+
+- Version: 0.2.0
+- Already has "publishConfig": { "access": "public" }
+- No internal dependents (safe test — no cascade needed)
+
+Good candidate. Low blast radius, simple package.                     

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "description": "Composable toolkit for building CLI applications with Commander",
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "access": "public"
     },
     "scripts": {
         "test": "bun test",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "description": "Shared CLI formatting and output utilities for axm-internal tools",
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "access": "public"
     },
     "scripts": {
         "test": "bun test",

--- a/packages/config-schema/package.json
+++ b/packages/config-schema/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "description": "A schema-first configuration runtime for applications",
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "access": "public"
     },
     "scripts": {
         "test": "bun test",

--- a/packages/git-db/package.json
+++ b/packages/git-db/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "description": "SQLite-backed git commit cache optimized for conventional commit messaging",
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "access": "public"
     },
     "scripts": {
         "cli": "bun run src/cli/index.ts",

--- a/packages/hono-kit/package.json
+++ b/packages/hono-kit/package.json
@@ -11,7 +11,7 @@
     },
     "description": "Opinionated Hono server wrapper with Zod-first validation",
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "access": "public"
     },
     "scripts": {
         "test": "bun test",

--- a/packages/schema-orm/package.json
+++ b/packages/schema-orm/package.json
@@ -4,7 +4,7 @@
     "type": "module",
     "main": "src/index.ts",
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "access": "public"
     },
     "scripts": {
         "test": "bun test",

--- a/packages/zod-helpers/package.json
+++ b/packages/zod-helpers/package.json
@@ -5,7 +5,7 @@
     "main": "src/index.ts",
     "description": "A collection of Zod v4 helpers",
     "publishConfig": {
-        "registry": "https://npm.pkg.github.com"
+        "access": "public"
     },
     "scripts": {
         "test": "bun test",


### PR DESCRIPTION
Updated `.npmrc` to use `registry.npmjs.org` with `NPM_TOKEN`
Replaced `publishConfig.registry` with `publishConfig.access: "public"`
in all 7 publishable packages
Updated `.github/workflows/release.yml` to use `NPM_TOKEN`
Removed `packages: write` permission from release workflow
Updated `.bun-create/axm-package/package.json` template
Updated docs: `CLAUDE.md`, `AGENTS.md`, `README.md`,
`monorepo-docs/conventions.md`, `monorepo-docs/release-versioning-pipeline.md`
Removed remaining Changesets references from `AGENTS.md`
Marked Step 8.1-8.3 complete in `release-cli-checklist.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated publishing from GitHub Packages to the public npm registry to simplify installs and standardize releases. Packages now publish with public access via `NPM_TOKEN`, and consumers can install `@axm-internal/*` with no registry setup.

- **Migration**
  - `.npmrc` now authenticates to `registry.npmjs.org` using `NPM_TOKEN`.
  - Replaced `publishConfig.registry` with `"publishConfig": { "access": "public" }` across all 7 packages and the `.bun-create/axm-package` template.
  - Updated `.github/workflows/release.yml` to use `NPM_TOKEN` and removed `packages: write` permission.
  - Docs updated for npmjs.com and `release-cli` (AGENTS example now uses `<package-path>`); added `monorepo-docs/todos.md` with `NPM_TOKEN` steps and the `@axm-internal/zod-helpers` test plan; migration checklist marks 8.1–8.3 complete, 8.4–8.5 pending first npm publish/secret.

<sup>Written for commit 9b5524f3cb1490ac6c99b951f406cac605c9005a. Summary will update on new commits. <a href="https://cubic.dev/pr/axm-internal/axm-internals/pull/58?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

